### PR TITLE
Deprecate `getErrorMessage` for `getMessage`, #1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,28 +2,29 @@
 
 ## v1.2.2
 
-+ Deprecated `TenantSecurityKMSException.getErrorMessage` in favor of `getMessage` to make the full error message more accessible.
+- Deprecated `TenantSecurityKMSException.getErrorMessage` in favor of `getMessage` to make the full error message more accessible.
+- All `TenantSecurityKMSException` constructors accept/set an `Exception.cause` if possible.
 
 ## v1.2.1
 
-+ Added an error message to the `TenantSecurityKMSException` error that occurs when requests to the Tenant Security Proxy could not be made. This error message will include the URL that was attempted to be reached and the error text from the original exception that occurred. The error code associated with this error will be `UNABLE_TO_MAKE_REQUEST`.
+- Added an error message to the `TenantSecurityKMSException` error that occurs when requests to the Tenant Security Proxy could not be made. This error message will include the URL that was attempted to be reached and the error text from the original exception that occurred. The error code associated with this error will be `UNABLE_TO_MAKE_REQUEST`.
 
 ## v1.2.0
 
-+ Added additional error codes to the `TenantSecurityKMSErrorCodes` enum for errors specific to failures when interacting with the tenants KMS. These errors will help differentiate between KMS errors that were caused by network outages, credential errors, etc so that the appropriate error can be communicated to the calling client.
-  + `KMS_AUTHORIZATION_FAILED`: Requests to the tenants KMS failed because the credentials provided in their config failed to authenticate against their KMS. This could be because the credentials were setup incorrectly or because they have been revoked/removed.
-  + `KMS_CONFIGURATION_INVALID`: Requests to the tenants KMS failed because the KMS key configuration was invalid or the permissions for the key that is being wrapped/unwrapped have been revoked/removed. This could be because the key configuration was setup incorrectly or because the key has been revoked/removed.
-  + `KMS_UNREACHABLE`: Requests to the tenants KMS failed because the KMS API wasn't reachable. This could be because of a temporarary network outage or service down situation. The Tenant Security Proxy will automatically perform a single retry for the request if this error occurs.
-  + The existing `KMS_WRAP_FAILED`/`KMS_UNWRAP_FAILED` error codes will now only occur when the request to the tenants KMS was successful but did not return the expected response.
-+ The `TenantSecurityKMSException` class now also contains the error message returned from Tenant Security Proxy and can be retrieved by calling `ex.getErrorMessage()`. This message will have additional context for the error that occured within the Tenant Security Proxy and will be specific to the KMS type being used. This message should be very helpful in logs to determine why requests are failing to the tenants KMS.
+- Added additional error codes to the `TenantSecurityKMSErrorCodes` enum for errors specific to failures when interacting with the tenants KMS. These errors will help differentiate between KMS errors that were caused by network outages, credential errors, etc so that the appropriate error can be communicated to the calling client.
+  - `KMS_AUTHORIZATION_FAILED`: Requests to the tenants KMS failed because the credentials provided in their config failed to authenticate against their KMS. This could be because the credentials were setup incorrectly or because they have been revoked/removed.
+  - `KMS_CONFIGURATION_INVALID`: Requests to the tenants KMS failed because the KMS key configuration was invalid or the permissions for the key that is being wrapped/unwrapped have been revoked/removed. This could be because the key configuration was setup incorrectly or because the key has been revoked/removed.
+  - `KMS_UNREACHABLE`: Requests to the tenants KMS failed because the KMS API wasn't reachable. This could be because of a temporarary network outage or service down situation. The Tenant Security Proxy will automatically perform a single retry for the request if this error occurs.
+  - The existing `KMS_WRAP_FAILED`/`KMS_UNWRAP_FAILED` error codes will now only occur when the request to the tenants KMS was successful but did not return the expected response.
+- The `TenantSecurityKMSException` class now also contains the error message returned from Tenant Security Proxy and can be retrieved by calling `ex.getErrorMessage()`. This message will have additional context for the error that occured within the Tenant Security Proxy and will be specific to the KMS type being used. This message should be very helpful in logs to determine why requests are failing to the tenants KMS.
 
 ## v1.1.1
 
-+ Fixed a bug where the user agent header send on requests to the Tenant Security Proxy would grow unbounded and eventually cause HTTP 413 errors.
+- Fixed a bug where the user agent header send on requests to the Tenant Security Proxy would grow unbounded and eventually cause HTTP 413 errors.
 
 ## v1.1.0
 
-+ Added support for Java8 compatibility.
+- Added support for Java8 compatibility.
 
 ### Compatibility
 
@@ -34,4 +35,3 @@ This version of the Tenant Security Java Client will only work with version `1.2
 ### Compatibility
 
 This version of the Tenant Security Java Client will only work with version `1.2.0+` of the Tenant Security Proxy container.
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,37 @@
+# Changelog
+
+## v1.2.2
+
++ Deprecated `TenantSecurityKMSException.getErrorMessage` in favor of `getMessage` to make the full error message more accessible.
+
+## v1.2.1
+
++ Added an error message to the `TenantSecurityKMSException` error that occurs when requests to the Tenant Security Proxy could not be made. This error message will include the URL that was attempted to be reached and the error text from the original exception that occurred. The error code associated with this error will be `UNABLE_TO_MAKE_REQUEST`.
+
+## v1.2.0
+
++ Added additional error codes to the `TenantSecurityKMSErrorCodes` enum for errors specific to failures when interacting with the tenants KMS. These errors will help differentiate between KMS errors that were caused by network outages, credential errors, etc so that the appropriate error can be communicated to the calling client.
+  + `KMS_AUTHORIZATION_FAILED`: Requests to the tenants KMS failed because the credentials provided in their config failed to authenticate against their KMS. This could be because the credentials were setup incorrectly or because they have been revoked/removed.
+  + `KMS_CONFIGURATION_INVALID`: Requests to the tenants KMS failed because the KMS key configuration was invalid or the permissions for the key that is being wrapped/unwrapped have been revoked/removed. This could be because the key configuration was setup incorrectly or because the key has been revoked/removed.
+  + `KMS_UNREACHABLE`: Requests to the tenants KMS failed because the KMS API wasn't reachable. This could be because of a temporarary network outage or service down situation. The Tenant Security Proxy will automatically perform a single retry for the request if this error occurs.
+  + The existing `KMS_WRAP_FAILED`/`KMS_UNWRAP_FAILED` error codes will now only occur when the request to the tenants KMS was successful but did not return the expected response.
++ The `TenantSecurityKMSException` class now also contains the error message returned from Tenant Security Proxy and can be retrieved by calling `ex.getErrorMessage()`. This message will have additional context for the error that occured within the Tenant Security Proxy and will be specific to the KMS type being used. This message should be very helpful in logs to determine why requests are failing to the tenants KMS.
+
+## v1.1.1
+
++ Fixed a bug where the user agent header send on requests to the Tenant Security Proxy would grow unbounded and eventually cause HTTP 413 errors.
+
+## v1.1.0
+
++ Added support for Java8 compatibility.
+
+### Compatibility
+
+This version of the Tenant Security Java Client will only work with version `1.2.0+` of the Tenant Security Proxy container.
+
+## v1.0.0
+
+### Compatibility
+
+This version of the Tenant Security Java Client will only work with version `1.2.0+` of the Tenant Security Proxy container.
+

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <groupId>com.ironcorelabs</groupId>
   <artifactId>tenant-security-java</artifactId>
   <packaging>jar</packaging>
-  <version>1.2.1</version>
+  <version>1.2.2</version>
   <name>tenant-security-java</name>
   <url>https://ironcorelabs.com/docs</url>
   <description>Java client library for the IronCore Labs Tenant Security Proxy.</description>

--- a/src/main/java/com/ironcorelabs/tenantsecurity/kms/v1/TenantSecurityKMSException.java
+++ b/src/main/java/com/ironcorelabs/tenantsecurity/kms/v1/TenantSecurityKMSException.java
@@ -20,13 +20,14 @@ public class TenantSecurityKMSException extends Exception {
      *
      * @param errorCode        The EncryptionServiceErrorCode that occured with this
      *                         error.
-     * @param errorMessage     The readable error message returned from the Tenant
-     *                         Security Proxy for this error.
      * @param httpResponseCode The HTTP response code returned from the
      *                         Tenant Security Proxy for this error.
+     * @param errorMessage     The readable error message returned from the Tenant
+     *                         Security Proxy for this error.
+     * @param cause            The Throwable that caused this one.
      */
-    public TenantSecurityKMSException(TenantSecurityKMSErrorCodes errorCode, String errorMessage, int httpResponseCode) {
-        super(errorMessage);
+    public TenantSecurityKMSException(TenantSecurityKMSErrorCodes errorCode, int httpResponseCode, String errorMessage, Throwable cause) {
+        super(errorMessage, cause);
         this.errorCode = errorCode;
         this.httpResponseCode = httpResponseCode;
     }
@@ -39,11 +40,49 @@ public class TenantSecurityKMSException extends Exception {
      *                         error.
      * @param httpResponseCode The HTTP response code returned from the
      *                         Tenant Security Proxy for this error.
+     * @param errorMessage     The readable error message returned from the Tenant
+     *                         Security Proxy for this error.
+     */
+    public TenantSecurityKMSException(TenantSecurityKMSErrorCodes errorCode, int httpResponseCode, String errorMessage) {
+        this(errorCode, httpResponseCode, errorMessage, null);
+    }
+
+    /**
+     * Create a new TenantSecurityKMSException with the provided error code and HTTP
+     * status code.
+     *
+     * @param errorCode        The EncryptionServiceErrorCode that occured with this
+     *                         error.
+     * @param httpResponseCode The HTTP response code returned from the
+     *                         Tenant Security Proxy for this error.
+     * @param cause            The Throwable that caused this one.
+     */
+    public TenantSecurityKMSException(TenantSecurityKMSErrorCodes errorCode, int httpResponseCode, Throwable cause) {
+        this(errorCode, httpResponseCode, errorCode.getMessage(), cause);
+    }
+
+    /**
+     * Create a new TenantSecurityKMSException with the provided error code and HTTP
+     * status code.
+     *
+     * @param errorCode        The EncryptionServiceErrorCode that occured with this
+     *                         error.
+     * @param httpResponseCode The HTTP response code returned from the
+     *                         Tenant Security Proxy for this error.
      */
     public TenantSecurityKMSException(TenantSecurityKMSErrorCodes errorCode, int httpResponseCode) {
-        super(errorCode.getMessage());
-        this.errorCode = errorCode;
-        this.httpResponseCode = httpResponseCode;
+        this(errorCode, httpResponseCode, errorCode.getMessage(), null);
+    }
+
+    /**
+     * Create a new TenantSecurityKMSException when the request to the API couldn't
+     * be made.
+     *
+     * @param errorCode The EncryptionServiceErrorCode that occured with this error.
+     * @param cause     The Throwable that caused this one.
+     */
+    public TenantSecurityKMSException(TenantSecurityKMSErrorCodes errorCode, Throwable cause) {
+        this(errorCode, 0, errorCode.getMessage(), cause);
     }
 
     /**

--- a/src/main/java/com/ironcorelabs/tenantsecurity/kms/v1/TenantSecurityKMSException.java
+++ b/src/main/java/com/ironcorelabs/tenantsecurity/kms/v1/TenantSecurityKMSException.java
@@ -13,7 +13,6 @@ public class TenantSecurityKMSException extends Exception {
     private static final long serialVersionUID = 1L;
     private TenantSecurityKMSErrorCodes errorCode;
     private int httpResponseCode;
-    private String errorMessage;
 
     /**
      * Create a new TenantSecurityKMSException with the provided error code and HTTP
@@ -27,10 +26,9 @@ public class TenantSecurityKMSException extends Exception {
      *                         Tenant Security Proxy for this error.
      */
     public TenantSecurityKMSException(TenantSecurityKMSErrorCodes errorCode, String errorMessage, int httpResponseCode) {
-        super(errorCode.getMessage());
+        super(errorMessage);
         this.errorCode = errorCode;
         this.httpResponseCode = httpResponseCode;
-        this.errorMessage = errorMessage;
     }
 
     /**
@@ -78,13 +76,15 @@ public class TenantSecurityKMSException extends Exception {
     }
 
     /**
-     * Get the HTTP error message sent back from the Tenant Security Proxy. Can contain additional
+     * Get an error message. Can contain additional
      * information about the specifics of why a request failed including errors specific to the KMS
-     * type that failed. May be be an empty string if no error was sent.
+     * type that failed.
      *
-     * @return The readable error message returned from the Tenant Security Proxy.
+     * @return The readable error message.
+     * @deprecated Use {@link #getMessage()} instead.
      */
+    @Deprecated
     public String getErrorMessage(){
-        return errorMessage;
+        return this.getMessage();
     }
 }

--- a/src/main/java/com/ironcorelabs/tenantsecurity/kms/v1/TenantSecurityKMSRequest.java
+++ b/src/main/java/com/ironcorelabs/tenantsecurity/kms/v1/TenantSecurityKMSRequest.java
@@ -83,7 +83,7 @@ public final class TenantSecurityKMSRequest {
             ErrorResponse errorResponse = resp.parseAs(ErrorResponse.class);
             if (errorResponse.getCode() > 0 && TenantSecurityKMSErrorCodes.valueOf(errorResponse.getCode()) != null) {
                 return new TenantSecurityKMSException(TenantSecurityKMSErrorCodes.valueOf(errorResponse.getCode()),
-                        errorResponse.getMessage(), resp.getStatusCode());
+                        resp.getStatusCode(), errorResponse.getMessage());
             }
         } catch (Exception e) {
             /* Fall through and return unknown error below */}
@@ -102,16 +102,17 @@ public final class TenantSecurityKMSRequest {
                     return resp.parseAs(WrappedDocumentKey.class);
                 }
                 throw parseFailureFromRequest(resp);
-            } catch (Exception e) {
-                if (e instanceof TenantSecurityKMSException) {
-                    throw new CompletionException(e);
+            } catch (Exception cause) {
+                if (cause instanceof TenantSecurityKMSException) {
+                    throw new CompletionException(cause);
                 }
                 throw new CompletionException(new TenantSecurityKMSException(
                         TenantSecurityKMSErrorCodes.UNABLE_TO_MAKE_REQUEST,
+                        0,
                         String.format(
-                                "Unable to make request to Tenant Security Proxy wrap endpoint. Endpoint requested: %s Error: %s",
-                                this.wrapEndpoint, e),
-                        0));
+                                "Unable to make request to Tenant Security Proxy wrap endpoint. Endpoint requested: %s",
+                                this.wrapEndpoint),
+                        cause));
             }
         }, webRequestExecutor);
     }
@@ -129,16 +130,17 @@ public final class TenantSecurityKMSRequest {
                     return resp.parseAs(UnwrappedDocumentKey.class).getDekBytes();
                 }
                 throw parseFailureFromRequest(resp);
-            } catch (Exception e) {
-                if (e instanceof TenantSecurityKMSException) {
-                    throw new CompletionException(e);
+            } catch (Exception cause) {
+                if (cause instanceof TenantSecurityKMSException) {
+                    throw new CompletionException(cause);
                 }
                 throw new CompletionException(new TenantSecurityKMSException(
                         TenantSecurityKMSErrorCodes.UNABLE_TO_MAKE_REQUEST,
+                        0,
                         String.format(
-                                "Unable to make request to Tenant Security Proxy unwrap endpoint. Endpoint requested: %s Error: %s",
-                                this.wrapEndpoint, e),
-                        0));
+                                "Unable to make request to Tenant Security Proxy unwrap endpoint. Endpoint requested: %s",
+                                this.wrapEndpoint),
+                        cause));
             }
         }, webRequestExecutor);
     }

--- a/src/test/java/com/ironcorelabs/tenantsecurity/kms/v1/KMSRequestTest.java
+++ b/src/test/java/com/ironcorelabs/tenantsecurity/kms/v1/KMSRequestTest.java
@@ -1,6 +1,7 @@
 package com.ironcorelabs.tenantsecurity.kms.v1;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
@@ -40,6 +41,7 @@ public class KMSRequestTest {
         } catch (ExecutionException e) {
             assertTrue(e.getCause() instanceof TenantSecurityKMSException);
             TenantSecurityKMSException esError = (TenantSecurityKMSException) e.getCause();
+            assertNotNull(esError.getCause());
             assertEquals(esError.getErrorCode(), TenantSecurityKMSErrorCodes.UNABLE_TO_MAKE_REQUEST);
         }
     }

--- a/src/test/java/com/ironcorelabs/tenantsecurity/kms/v1/LocalRoundTrip.java
+++ b/src/test/java/com/ironcorelabs/tenantsecurity/kms/v1/LocalRoundTrip.java
@@ -62,7 +62,7 @@ public class LocalRoundTrip {
             if (e.getCause() instanceof TenantSecurityKMSException) {
                 TenantSecurityKMSException kmsError = (TenantSecurityKMSException) e.getCause();
                 TenantSecurityKMSErrorCodes errorCode = kmsError.getErrorCode();
-                System.out.println("\nError Message: " + kmsError.getErrorMessage());
+                System.out.println("\nError Message: " + kmsError.getMessage());
                 System.out.println("\nError Code: " + errorCode.getCode());
                 System.out.println("\nError Code Info: " + errorCode.getMessage() + "\n");
             }


### PR DESCRIPTION
- Deprecated `TenantSecurityKMSException.getErrorMessage` in favor of `getMessage` to make the full error message more accessible.
- All `TenantSecurityKMSException` constructors accept/set an `Exception.cause` if possible to provide better stack traces.

old stack trace:
```console
com.ironcorelabs.tenantsecurity.kms.v1.TenantSecurityKMSException: Unable to make request to Tenant Security Proxy wrap endpoint.
	at com.ironcorelabs.tenantsecurity.kms.v1.TenantSecurityKMSRequest.lambda$1(TenantSecurityKMSRequest.java:114)
	at java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1604)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)

```

new stack trace
```console
com.ironcorelabs.tenantsecurity.kms.v1.TenantSecurityKMSException: Unable to make request to Tenant Security Proxy wrap endpoint. Endpoint requested: http://thisdomaindoesnotexist.eta/api/1/document/wrap
	at com.ironcorelabs.tenantsecurity.kms.v1.TenantSecurityKMSRequest.lambda$1(TenantSecurityKMSRequest.java:115)
	at java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1604)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
Caused by: java.net.ConnectException: Connection refused (Connection refused)
	at java.net.PlainSocketImpl.socketConnect(Native Method)
	at java.net.AbstractPlainSocketImpl.doConnect(AbstractPlainSocketImpl.java:350)
	at java.net.AbstractPlainSocketImpl.connectToAddress(AbstractPlainSocketImpl.java:206)
	at java.net.AbstractPlainSocketImpl.connect(AbstractPlainSocketImpl.java:188)
	at java.net.SocksSocketImpl.connect(SocksSocketImpl.java:392)
	at java.net.Socket.connect(Socket.java:607)
	at sun.net.NetworkClient.doConnect(NetworkClient.java:175)
	at sun.net.www.http.HttpClient.openServer(HttpClient.java:463)
	at sun.net.www.http.HttpClient.openServer(HttpClient.java:558)
	at sun.net.www.http.HttpClient.<init>(HttpClient.java:242)
	at sun.net.www.http.HttpClient.New(HttpClient.java:339)
	at sun.net.www.http.HttpClient.New(HttpClient.java:357)
	at sun.net.www.protocol.http.HttpURLConnection.getNewHttpClient(HttpURLConnection.java:1226)
	at sun.net.www.protocol.http.HttpURLConnection.plainConnect0(HttpURLConnection.java:1162)
	at sun.net.www.protocol.http.HttpURLConnection.plainConnect(HttpURLConnection.java:1056)
	at sun.net.www.protocol.http.HttpURLConnection.connect(HttpURLConnection.java:990)
	at sun.net.www.protocol.http.HttpURLConnection.getOutputStream0(HttpURLConnection.java:1340)
	at sun.net.www.protocol.http.HttpURLConnection.getOutputStream(HttpURLConnection.java:1315)
	at com.google.api.client.http.javanet.NetHttpRequest.execute(NetHttpRequest.java:113)
	at com.google.api.client.http.javanet.NetHttpRequest.execute(NetHttpRequest.java:84)
	at com.google.api.client.http.HttpRequest.execute(HttpRequest.java:1040)
	at com.ironcorelabs.tenantsecurity.kms.v1.TenantSecurityKMSRequest.lambda$1(TenantSecurityKMSRequest.java:100)
```