### PR TITLE
Make the port easier to change across the tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <groupId>com.ironcorelabs</groupId>
   <artifactId>tenant-security-java</artifactId>
   <packaging>jar</packaging>
-  <version>1.2.2</version>
+  <version>2.0.0-SNAPSHOT</version>
   <name>tenant-security-java</name>
   <url>https://ironcorelabs.com/docs</url>
   <description>Java client library for the IronCore Labs Tenant Security Proxy.</description>

--- a/src/test/java/com/ironcorelabs/tenantsecurity/kms/v1/DevIntegrationTest.java
+++ b/src/test/java/com/ironcorelabs/tenantsecurity/kms/v1/DevIntegrationTest.java
@@ -56,7 +56,7 @@ public class DevIntegrationTest {
     }
 
     private CompletableFuture<TenantSecurityKMSClient> getClient() {
-        return TenantSecurityKMSClient.create("http://localhost:7777", this.INTEGRATION_API_KEY);
+        return TenantSecurityKMSClient.create(TestSettings.TSP_ADDRESS + TestSettings.TSP_PORT, this.INTEGRATION_API_KEY);
     }
 
     private Map<String, byte[]> getRoundtripDataToEncrypt() throws Exception {

--- a/src/test/java/com/ironcorelabs/tenantsecurity/kms/v1/KMSRequestTest.java
+++ b/src/test/java/com/ironcorelabs/tenantsecurity/kms/v1/KMSRequestTest.java
@@ -48,7 +48,7 @@ public class KMSRequestTest {
 
     public void errorCodeWhenApiKeyIsWrong() throws Exception {
         CompletableFuture<EncryptedDocument> encrypt = TenantSecurityKMSClient
-                .create("http://localhost:7777", "wrongKey")
+                .create(TestSettings.TSP_ADDRESS + TestSettings.TSP_PORT, "wrongKey")
                 .thenCompose(client -> client.encrypt(getDocument(), getMetadata()));
 
         try {
@@ -67,7 +67,7 @@ public class KMSRequestTest {
         EncryptedDocument eDoc = new EncryptedDocument(documentMap, "d2hhdCBhIHdhc3RlIG9mIHRpbWUK");
 
         CompletableFuture<PlaintextDocument> decrypt = TenantSecurityKMSClient
-                .create("http://localhost:7777", NotPrimaryAndDisabledConfigs.INTEGRATION_API_KEY)
+                .create(TestSettings.TSP_ADDRESS + TestSettings.TSP_PORT, NotPrimaryAndDisabledConfigs.INTEGRATION_API_KEY)
                 .thenCompose(client -> client.decrypt(eDoc, getMetadata()));
 
         try {

--- a/src/test/java/com/ironcorelabs/tenantsecurity/kms/v1/LocalBatch.java
+++ b/src/test/java/com/ironcorelabs/tenantsecurity/kms/v1/LocalBatch.java
@@ -59,7 +59,7 @@ public class LocalBatch {
     public void oldBatchRoundtrip() throws Exception {
         DocumentMetadata context = new DocumentMetadata(this.TENANT_ID, "integrationTest", "sample");
 
-        TenantSecurityKMSClient client = new TenantSecurityKMSClient("http://localhost:7777", this.API_KEY);
+        TenantSecurityKMSClient client = new TenantSecurityKMSClient(TestSettings.TSP_ADDRESS + TestSettings.TSP_PORT, this.API_KEY);
 
         int batchSize = 25;
         int batchRepetitions = 50;
@@ -103,7 +103,7 @@ public class LocalBatch {
     public void newBatchRoundtrip() throws Exception {
         DocumentMetadata context = new DocumentMetadata(this.TENANT_ID, "integrationTest", "sample");
 
-        TenantSecurityKMSClient client = new TenantSecurityKMSClient("http://localhost:7777", this.API_KEY);
+        TenantSecurityKMSClient client = new TenantSecurityKMSClient(TestSettings.TSP_ADDRESS + TestSettings.TSP_PORT, this.API_KEY);
 
         int batchSize = 25;
         int batchRepetitions = 50;

--- a/src/test/java/com/ironcorelabs/tenantsecurity/kms/v1/LocalRoundTrip.java
+++ b/src/test/java/com/ironcorelabs/tenantsecurity/kms/v1/LocalRoundTrip.java
@@ -36,7 +36,7 @@ public class LocalRoundTrip {
         Map<String, byte[]> documentMap = getRoundtripDataToEncrypt();
 
         CompletableFuture<PlaintextDocument> roundtrip = TenantSecurityKMSClient
-                .create("http://localhost:7777", this.API_KEY).thenCompose(client -> {
+                .create(TestSettings.TSP_ADDRESS + TestSettings.TSP_PORT, this.API_KEY).thenCompose(client -> {
 
                     try {
                         return client.encrypt(documentMap, context).thenCompose(encryptedResults -> {

--- a/src/test/java/com/ironcorelabs/tenantsecurity/kms/v1/NotPrimaryAndDisabledConfigs.java
+++ b/src/test/java/com/ironcorelabs/tenantsecurity/kms/v1/NotPrimaryAndDisabledConfigs.java
@@ -54,7 +54,7 @@ public class NotPrimaryAndDisabledConfigs {
     }
 
     private CompletableFuture<TenantSecurityKMSClient> getClient() {
-        return TenantSecurityKMSClient.create("http://localhost:7777",
+        return TenantSecurityKMSClient.create(TestSettings.TSP_ADDRESS + TestSettings.TSP_PORT,
                 NotPrimaryAndDisabledConfigs.INTEGRATION_API_KEY);
     }
 

--- a/src/test/java/com/ironcorelabs/tenantsecurity/kms/v1/TestSettings.java
+++ b/src/test/java/com/ironcorelabs/tenantsecurity/kms/v1/TestSettings.java
@@ -1,0 +1,6 @@
+package com.ironcorelabs.tenantsecurity.kms.v1;
+
+public final class TestSettings {
+    public static String TSP_ADDRESS = "http://localhost";
+    public static String TSP_PORT = ":7777";
+}


### PR DESCRIPTION
Supports testing against the docker image, not just local.

Bump the version for release.