### PR TITLE
Use camelCase for REST endpoints

### DIFF
--- a/src/main/java/com/ironcorelabs/tenantsecurity/kms/v1/DocumentMetadata.java
+++ b/src/main/java/com/ironcorelabs/tenantsecurity/kms/v1/DocumentMetadata.java
@@ -162,14 +162,14 @@ public class DocumentMetadata {
      */
     public Map<String, Object> getAsPostData() {
         Map<String, Object> postData = new HashMap<>();
-        postData.put("tenantID", tenantId);
-        postData.put("requestingID", requestingUserOrServiceId);
+        postData.put("tenantId", tenantId);
+        postData.put("requestingId", requestingUserOrServiceId);
         postData.put("dataLabel", dataLabel);
         if (requestId != null) {
-            postData.put("requestID", requestId);
+            postData.put("requestId", requestId);
         }
-        postData.put("sourceIP", sourceIp);
-        postData.put("objectID", objectId);
+        postData.put("sourceIp", sourceIp);
+        postData.put("objectId", objectId);
 
         Map<String, String> customFields = new HashMap<>();
         for (Map.Entry<String, String> entry : otherData.entrySet()) {

--- a/src/test/java/com/ironcorelabs/tenantsecurity/kms/v1/DocumentMetadataTest.java
+++ b/src/test/java/com/ironcorelabs/tenantsecurity/kms/v1/DocumentMetadataTest.java
@@ -33,12 +33,12 @@ public class DocumentMetadataTest {
         DocumentMetadata meta = new DocumentMetadata("customerID", "svcID", "classification");
 
         Map<String, Object> postData = meta.getAsPostData();
-        assertEquals(postData.get("tenantID"), "customerID");
-        assertEquals(postData.get("requestingID"), "svcID");
+        assertEquals(postData.get("tenantId"), "customerID");
+        assertEquals(postData.get("requestingId"), "svcID");
         assertEquals(postData.get("dataLabel"), "classification");
-        assertEquals(postData.get("requestID"), null);
-        assertEquals(postData.get("sourceIP"), null);
-        assertEquals(postData.get("objectID"), null);
+        assertEquals(postData.get("requestId"), null);
+        assertEquals(postData.get("sourceIp"), null);
+        assertEquals(postData.get("objectId"), null);
 
         Map<String, String> customData = (Map<String, String>) postData.get("customFields");
         assertEquals(customData.size(), 0);
@@ -52,12 +52,12 @@ public class DocumentMetadataTest {
         DocumentMetadata meta = new DocumentMetadata("customerID", "svcID", "classification", arbData, "requestID", "8.8.8.8", "document-5");
 
         Map<String, Object> postData = meta.getAsPostData();
-        assertEquals(postData.get("tenantID"), "customerID");
-        assertEquals(postData.get("requestingID"), "svcID");
+        assertEquals(postData.get("tenantId"), "customerID");
+        assertEquals(postData.get("requestingId"), "svcID");
         assertEquals(postData.get("dataLabel"), "classification");
-        assertEquals(postData.get("requestID"), "requestID");
-        assertEquals(postData.get("sourceIP"), "8.8.8.8");
-        assertEquals(postData.get("objectID"), "document-5");
+        assertEquals(postData.get("requestId"), "requestID");
+        assertEquals(postData.get("sourceIp"), "8.8.8.8");
+        assertEquals(postData.get("objectId"), "document-5");
 
         Map<String, String> customData = (Map<String, String>) postData.get("customFields");
         assertEquals(customData.get("custom"), "field");


### PR DESCRIPTION
These are all the changes to the endpoints. 

There are places in the tests that we used things like `customerID`, and I didn't know how aggressively we wanted to change everything.

Waiting on all the TSP changes to settle before merging.