### PR TITLE
Add rekeyDocument method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.1.0 (Unreleased)
+
+- Added `TenantSecurityClient.rekeyDocument` method and supporting `RekeyedDocumentKey` type
+
 ## v3.0.1
 
 - Renamed some security events for better consistency
@@ -8,7 +12,7 @@
 
 - Added `TenantSecurityClient.logSecurityEvent` method and supporting `SecurityEvent` and `EventMetadata` types
 - Standardized `EventMetadata` and `DocumentMetadata` to similar interfaces with the TSP
-- Introduced an exception hierachy based on TSP error codes. `TenantSecurityKMSException` renamed to `TenantSecurityException` and
+- Introduced an exception hierarchy based on TSP error codes. `TenantSecurityKMSException` renamed to `TenantSecurityException` and
   `KmsException`, `SecurityEventException`, and `TspServiceException` are subclasses.
 - Renamed `TenantSecurityKMSClient` to `TenantSecurityClient`
 - Removed deprecated list based batch methods
@@ -24,7 +28,7 @@ This version of the Tenant Security Java Client will only work with version `3.0
 
 ## v2.0.2
 
-- Added a `timeout` option to the `TenantSecurityKMSClient` this timeout is applied to the connection negotiaton _and_ the read from the TSP, so the worst case of a very unstable connection is 2x the `timeout` value.
+- Added a `timeout` option to the `TenantSecurityKMSClient` this timeout is applied to the connection negotiation _and_ the read from the TSP, so the worst case of a very unstable connection is 2x the `timeout` value.
 
 ## v2.0.1
 
@@ -52,9 +56,9 @@ This version of the Tenant Security Java Client will only work with version `2.0
 - Added additional error codes to the `TenantSecurityKMSErrorCodes` enum for errors specific to failures when interacting with the tenants KMS. These errors will help differentiate between KMS errors that were caused by network outages, credential errors, etc so that the appropriate error can be communicated to the calling client.
   - `KMS_AUTHORIZATION_FAILED`: Requests to the tenants KMS failed because the credentials provided in their config failed to authenticate against their KMS. This could be because the credentials were setup incorrectly or because they have been revoked/removed.
   - `KMS_CONFIGURATION_INVALID`: Requests to the tenants KMS failed because the KMS key configuration was invalid or the permissions for the key that is being wrapped/unwrapped have been revoked/removed. This could be because the key configuration was setup incorrectly or because the key has been revoked/removed.
-  - `KMS_UNREACHABLE`: Requests to the tenants KMS failed because the KMS API wasn't reachable. This could be because of a temporarary network outage or service down situation. The Tenant Security Proxy will automatically perform a single retry for the request if this error occurs.
+  - `KMS_UNREACHABLE`: Requests to the tenants KMS failed because the KMS API wasn't reachable. This could be because of a temporary network outage or service down situation. The Tenant Security Proxy will automatically perform a single retry for the request if this error occurs.
   - The existing `KMS_WRAP_FAILED`/`KMS_UNWRAP_FAILED` error codes will now only occur when the request to the tenants KMS was successful but did not return the expected response.
-- The `TenantSecurityKMSException` class now also contains the error message returned from Tenant Security Proxy and can be retrieved by calling `ex.getErrorMessage()`. This message will have additional context for the error that occured within the Tenant Security Proxy and will be specific to the KMS type being used. This message should be very helpful in logs to determine why requests are failing to the tenants KMS.
+- The `TenantSecurityKMSException` class now also contains the error message returned from Tenant Security Proxy and can be retrieved by calling `ex.getErrorMessage()`. This message will have additional context for the error that occurred within the Tenant Security Proxy and will be specific to the KMS type being used. This message should be very helpful in logs to determine why requests are failing to the tenants KMS.
 
 ## v1.1.1
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ See our [TSP documentation](https://ironcorelabs.com/docs/customer-managed-keys/
 
 ## Tests
 
-This client has both a set of unit tests as well as several integration test suites. Because of the complexity of the various services requried to run non-unit test suites, these tests have a lot more setup requried which is explained below.
+This client has both a set of unit tests as well as several integration test suites. Because of the complexity of the various services required to run non-unit test suites, these tests have a lot more setup required which is explained below.
 
 #### Unit Tests
 
@@ -16,7 +16,7 @@ Tests that check functionality that is contained within the client.
 
 #### Local Development Integration Tests
 
-These tests are meant for local devlopers to be able to do a full end-to-end test from the client all the way through to the Config Broker. This test will perform a full round-trip encryption and decryption and verify that the data is successfully decrypted to it's original value. This test assumes that you've done the work of setting up the Tenant Security Proxy from above as well as setting up the associated Config Broker vendor account with a tenant and a KMS config. Open the [`LocalRoundTrip.java`](src/test/java/com/ironcorelabs/tenantsecurity/kms/v1/LocalRoundTrip.java) file and set the values for your `TENANT_ID` and `API_KEY` within the test class.
+These tests are meant for local developers to be able to do a full end-to-end test from the client all the way through to the Config Broker. This test will perform a full round-trip encryption and decryption and verify that the data is successfully decrypted to it's original value. This test assumes that you've done the work of setting up the Tenant Security Proxy from above as well as setting up the associated Config Broker vendor account with a tenant and a KMS config. Open the [`LocalRoundTrip.java`](src/test/java/com/ironcorelabs/tenantsecurity/kms/v1/LocalRoundTrip.java) file and set the values for your `TENANT_ID` and `API_KEY` within the test class.
 
 Once complete, perform the following steps
 
@@ -25,29 +25,29 @@ Once complete, perform the following steps
 
 #### Complete Integration Tests
 
-We've created a number of accounts within a Config Broker dev enviroment that have tenants set up for all the different KMS types that we support. This allows us to run a more complete suite of integration tests that exercise more parts of both the client as well as the Tenant Security Proxy. These tests are not runnable by the public. You can view the results of these test runs in [CI](https://github.com/IronCoreLabs/tenant-security-client-java/actions).
+We've created a number of accounts within a Config Broker dev environment that have tenants set up for all the different KMS types that we support. This allows us to run a more complete suite of integration tests that exercise more parts of both the client as well as the Tenant Security Proxy. These tests are not runnable by the public. You can view the results of these test runs in [CI](https://github.com/IronCoreLabs/tenant-security-client-java/actions).
 
 ## Deploy
 
 We deploy the SDK to [Maven Central](https://search.maven.org/artifact/com.ironcorelabs/tenant-security-java/).
 
 - You'll need to be authenticated and associated to our IronCore Sonatype account. This requires a user name and password for the
-`sonatype-nexus` server to be stored in your `.m2/settings.xml` file. The user name and password we use for releasing are stored
-on Drive in `IT_Info/sonatype-info.txt.iron`.
+  `sonatype-nexus` server to be stored in your `.m2/settings.xml` file. The user name and password we use for releasing are stored
+  on Drive in `IT_Info/sonatype-info.txt.iron`.
 - You'll also need a GPG signing key to sign the release. Decrypt `IT_Info/pgp/rsa-signing-subkey.asc.iron`, then
-`gpg --import rsa_signing_key.asc`.
+  `gpg --import rsa_signing_key.asc`.
 - Update the `<version>` in `pom.xml`.
 - Run `mvn clean source:jar javadoc:jar deploy -Dsuite=test-suites/test-unit` to deploy the release to Maven Central.
-**NOTE**: this command will need the passphrase associated with the GPG signing key.
-If that hasn't been entered recently, the command will error with a "signing failed" message.
-You need to do a signing operation like `gpg -s pom.xml`, then enter the passphrase for the key.
-After that, re-run the `mvn` commmand.
+  **NOTE**: this command will need the passphrase associated with the GPG signing key.
+  If that hasn't been entered recently, the command will error with a "signing failed" message.
+  You need to do a signing operation like `gpg -s pom.xml`, then enter the passphrase for the key.
+  After that, re-run the `mvn` command.
 - When the artifacts have been deployed, you need to go to `https://oss.sonatype.org`, log in using the `icl-devops` username and
-password, and find the new release in the *Staging Repositories*. You must close that repository and then release it in order to
-actually push the package out to the public repo.
-
+  password, and find the new release in the _Staging Repositories_. You must close that repository and then release it in order to
+  actually push the package out to the public repo.
 
 This is a sample `settings.xml` file for `maven`:
+
 ```
 <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
@@ -69,6 +69,7 @@ If your tests don't build against the default branch of that repo, you can chang
 comment should contain the string `CI_branches` and a JSON object like
 `{"tenant-security-proxy": "some_branch"}`. You can include formatting, prose, or a haiku,
 but no `{` or `}` characters. Example:
+
 ```
 CI_branches: `{"tenant-security-proxy": "some_branch"}`
 

--- a/src/main/java/com/ironcorelabs/tenantsecurity/kms/v1/RekeyedDocumentKey.java
+++ b/src/main/java/com/ironcorelabs/tenantsecurity/kms/v1/RekeyedDocumentKey.java
@@ -1,0 +1,16 @@
+package com.ironcorelabs.tenantsecurity.kms.v1;
+
+import com.google.api.client.util.Key;
+
+/**
+ * An EDEK made by wrapping an existing encrypted document with a tenant's KMS, in
+ * Base64 format.
+ */
+public class RekeyedDocumentKey {
+    @Key
+    private String edek;
+
+    public String getEdek() {
+        return this.edek;
+    }
+}

--- a/src/main/java/com/ironcorelabs/tenantsecurity/kms/v1/TenantSecurityClient.java
+++ b/src/main/java/com/ironcorelabs/tenantsecurity/kms/v1/TenantSecurityClient.java
@@ -456,7 +456,7 @@ public final class TenantSecurityClient implements Closeable {
      *
      * @param plaintextDocuments Map of document ID to map of fields to encrypt.
      * @param metadata           Metadata about all of the documents being encrypted
-     * @return Collection of successes and failures that occured during operation. The keys of each
+     * @return Collection of successes and failures that occurred during operation. The keys of each
      *         map returned will be the same keys provided in the original plaintextDocuments map.
      */
     public CompletableFuture<BatchResult<EncryptedDocument>> encryptBatch(
@@ -485,7 +485,7 @@ public final class TenantSecurityClient implements Closeable {
      *
      * @param plaintextDocuments Map of previously encrypted document from ID to document.
      * @param metadata           Metadata about all of the documents being encrypted
-     * @return Collection of successes and failures that occured during operation. The keys of each
+     * @return Collection of successes and failures that occurred during operation. The keys of each
      *         map returned will be the same keys provided in the original plaintextDocuments map.
      */
     public CompletableFuture<BatchResult<EncryptedDocument>> encryptExistingBatch(
@@ -529,6 +529,22 @@ public final class TenantSecurityClient implements Closeable {
     }
 
     /**
+     * Re-key an EncryptedDocument to a new tenant without decrypting the document data. Decrypts the 
+     * document's encrypted document key (EDEK) then re-encrypts it to the new tenant. The DEK is then discarded.
+     * 
+     * @param encryptedDocument Document to re-key which includes encrypted bytes as well as EDEK.
+     * @param metadata          Metadata about the document being re-keyed.
+     * @param newTenantId       Tenant ID the document should be re-keyed to.
+     * @return                  EncryptedDocument that contains the new EDEK and unaltered encrypted fields.
+     */
+    public CompletableFuture<EncryptedDocument> rekeyDocument(EncryptedDocument encryptedDocument,
+            DocumentMetadata metadata, String newTenantId) {
+        return this.encryptionService.rekey(encryptedDocument.getEdek(), metadata, newTenantId).thenApply(newKey -> {
+            return new EncryptedDocument(encryptedDocument.getEncryptedFields(), newKey.getEdek());
+        });
+    }
+
+    /**
      * Decrypt a map of documents from the ID of the document to its encrypted content. Makes a call
      * out to the Tenant Security Proxy to decrypt all of the EDEKs in each document. This function
      * supports partial failure so it returns two Maps, one of document ID to successfully decrypted
@@ -537,7 +553,7 @@ public final class TenantSecurityClient implements Closeable {
      * @param encryptedDocuments Map of documents to decrypt from ID of the document to the
      *                           EncryptedDocument
      * @param metadata           Metadata to use for each decrypt operation.
-     * @return Collection of successes and failures that occured during operation. The keys of each
+     * @return Collection of successes and failures that occurred during operation. The keys of each
      *         map returned will be the same keys provided in the original encryptedDocuments map.
      */
     public CompletableFuture<BatchResult<PlaintextDocument>> decryptBatch(

--- a/src/main/java/com/ironcorelabs/tenantsecurity/kms/v1/TenantSecurityClient.java
+++ b/src/main/java/com/ironcorelabs/tenantsecurity/kms/v1/TenantSecurityClient.java
@@ -531,6 +531,7 @@ public final class TenantSecurityClient implements Closeable {
         /**
          * Re-key an EncryptedDocument to a new tenant without decrypting the document data. Decrypts the 
          * document's encrypted document key (EDEK) then re-encrypts it to the new tenant. The DEK is then discarded.
+         * The old tenant and new tenant can be the same in order to re-key the document to the tenant's latest primary config. 
          * 
          * @param encryptedDocument Document to re-key which includes encrypted bytes as well as EDEK.
          * @param metadata          Metadata about the document being re-keyed.

--- a/src/main/java/com/ironcorelabs/tenantsecurity/kms/v1/TenantSecurityClient.java
+++ b/src/main/java/com/ironcorelabs/tenantsecurity/kms/v1/TenantSecurityClient.java
@@ -528,21 +528,21 @@ public final class TenantSecurityClient implements Closeable {
                 });
     }
 
-    /**
-     * Re-key an EncryptedDocument to a new tenant without decrypting the document data. Decrypts the 
-     * document's encrypted document key (EDEK) then re-encrypts it to the new tenant. The DEK is then discarded.
-     * 
-     * @param encryptedDocument Document to re-key which includes encrypted bytes as well as EDEK.
-     * @param metadata          Metadata about the document being re-keyed.
-     * @param newTenantId       Tenant ID the document should be re-keyed to.
-     * @return                  EncryptedDocument that contains the new EDEK and unaltered encrypted fields.
-     */
-    public CompletableFuture<EncryptedDocument> rekeyDocument(EncryptedDocument encryptedDocument,
-            DocumentMetadata metadata, String newTenantId) {
-        return this.encryptionService.rekey(encryptedDocument.getEdek(), metadata, newTenantId).thenApply(newKey -> {
-            return new EncryptedDocument(encryptedDocument.getEncryptedFields(), newKey.getEdek());
-        });
-    }
+        /**
+         * Re-key an EncryptedDocument to a new tenant without decrypting the document data. Decrypts the 
+         * document's encrypted document key (EDEK) then re-encrypts it to the new tenant. The DEK is then discarded.
+         * 
+         * @param encryptedDocument Document to re-key which includes encrypted bytes as well as EDEK.
+         * @param metadata          Metadata about the document being re-keyed.
+         * @param newTenantId       Tenant ID the document should be re-keyed to.
+         * @return                  EncryptedDocument that contains the new EDEK and unaltered encrypted fields.
+         */
+        public CompletableFuture<EncryptedDocument> rekeyDocument(EncryptedDocument encryptedDocument,
+                        DocumentMetadata metadata, String newTenantId) {
+                return this.encryptionService.rekey(encryptedDocument.getEdek(), metadata, newTenantId)
+                                .thenApply(newKey -> new EncryptedDocument(encryptedDocument.getEncryptedFields(),
+                                                newKey.getEdek()));
+        }
 
     /**
      * Decrypt a map of documents from the ID of the document to its encrypted content. Makes a call

--- a/src/main/java/com/ironcorelabs/tenantsecurity/kms/v1/TenantSecurityRequest.java
+++ b/src/main/java/com/ironcorelabs/tenantsecurity/kms/v1/TenantSecurityRequest.java
@@ -47,6 +47,7 @@ final class TenantSecurityRequest implements Closeable {
     private final GenericUrl batchWrapEndpoint;
     private final GenericUrl unwrapEndpoint;
     private final GenericUrl batchUnwrapEndpoint;
+    private final GenericUrl rekeyEndpoint;
     private final GenericUrl securityEventEndpoint;
     private final HttpRequestFactory requestFactory;
     private final int timeout;
@@ -62,6 +63,7 @@ final class TenantSecurityRequest implements Closeable {
         this.batchWrapEndpoint = new GenericUrl(tspApiPrefix + "document/batch-wrap");
         this.unwrapEndpoint = new GenericUrl(tspApiPrefix + "document/unwrap");
         this.batchUnwrapEndpoint = new GenericUrl(tspApiPrefix + "document/batch-unwrap");
+        this.rekeyEndpoint = new GenericUrl(tspApiPrefix + "document/rekey");
         this.securityEventEndpoint = new GenericUrl(tspApiPrefix + "event/security-event");
 
         this.webRequestExecutor = Executors.newFixedThreadPool(requestThreadSize);
@@ -200,6 +202,19 @@ final class TenantSecurityRequest implements Closeable {
                 this.batchWrapEndpoint);
         return this.makeRequestAndParseFailure(this.batchUnwrapEndpoint, postData,
                 BatchUnwrappedDocumentKeys.class, error);
+    }
+
+    /**
+     * Request re-key endpoint to unwrap an EDEK encrypted to the metadata's tenantId and then wrap it to the newTenantId.
+     */
+    CompletableFuture<RekeyedDocumentKey> rekey(String edek, DocumentMetadata metadata, String newTenantId) {
+        Map<String, Object> postData = metadata.getAsPostData();
+        postData.put("encryptedDocumentKey", edek);
+        postData.put("newTenantId", newTenantId);
+        String error = String.format(
+                "Unable to make request to Tenant Security Proxy wrap endpoint. Endpoint requested: %s",
+                this.rekeyEndpoint);
+        return this.makeRequestAndParseFailure(this.rekeyEndpoint, postData, RekeyedDocumentKey.class, error);
     }
 
     /**

--- a/src/main/java/com/ironcorelabs/tenantsecurity/kms/v1/TenantSecurityRequest.java
+++ b/src/main/java/com/ironcorelabs/tenantsecurity/kms/v1/TenantSecurityRequest.java
@@ -212,7 +212,7 @@ final class TenantSecurityRequest implements Closeable {
         postData.put("encryptedDocumentKey", edek);
         postData.put("newTenantId", newTenantId);
         String error = String.format(
-                "Unable to make request to Tenant Security Proxy wrap endpoint. Endpoint requested: %s",
+                "Unable to make request to Tenant Security Proxy rekey endpoint. Endpoint requested: %s",
                 this.rekeyEndpoint);
         return this.makeRequestAndParseFailure(this.rekeyEndpoint, postData, RekeyedDocumentKey.class, error);
     }

--- a/src/test/java/com/ironcorelabs/tenantsecurity/kms/v1/DevIntegrationTest.java
+++ b/src/test/java/com/ironcorelabs/tenantsecurity/kms/v1/DevIntegrationTest.java
@@ -201,6 +201,7 @@ public class DevIntegrationTest {
                 return client.encrypt(documentMap, metadata).thenCompose(encryptedResults -> {
                     return client.rekeyDocument(encryptedResults, metadata, this.AZURE_TENANT_ID)
                             .thenCompose(rekeyResults -> {
+                                assertEquals(rekeyResults.getEncryptedFields(), encryptedResults.getEncryptedFields());
                                 DocumentMetadata newMetadata = getRoundtripMetadata(this.AZURE_TENANT_ID);
                                 return client.decrypt(rekeyResults, newMetadata);
                             });

--- a/src/test/java/com/ironcorelabs/tenantsecurity/kms/v1/DevIntegrationTest.java
+++ b/src/test/java/com/ironcorelabs/tenantsecurity/kms/v1/DevIntegrationTest.java
@@ -192,6 +192,30 @@ public class DevIntegrationTest {
         assertEqualBytes(decryptedValuesMap.get("doc3"), documentMap.get("doc3"));
     }
 
+    public void roundTripRekeyAWSToAzure() throws Exception {
+        DocumentMetadata metadata = getRoundtripMetadata(this.AWS_TENANT_ID);
+        Map<String, byte[]> documentMap = getRoundtripDataToEncrypt();
+
+        CompletableFuture<PlaintextDocument> roundtrip = getClient().thenCompose(client -> {
+            try {
+                return client.encrypt(documentMap, metadata).thenCompose(encryptedResults -> {
+                    return client.rekeyDocument(encryptedResults, metadata, this.AZURE_TENANT_ID)
+                            .thenCompose(rekeyResults -> {
+                                DocumentMetadata newMetadata = getRoundtripMetadata(this.AZURE_TENANT_ID);
+                                return client.decrypt(rekeyResults, newMetadata);
+                            });
+                });
+            } catch (Exception e) {
+                throw new CompletionException(e);
+            }
+        });
+
+        Map<String, byte[]> decryptedValuesMap = roundtrip.get().getDecryptedFields();
+        assertEqualBytes(decryptedValuesMap.get("doc1"), documentMap.get("doc1"));
+        assertEqualBytes(decryptedValuesMap.get("doc2"), documentMap.get("doc2"));
+        assertEqualBytes(decryptedValuesMap.get("doc3"), documentMap.get("doc3"));
+    }
+
     public void batchRoundtripTest() throws Exception {
         DocumentMetadata metadata = getRoundtripMetadata(this.GCP_TENANT_ID);
 

--- a/src/test/java/com/ironcorelabs/tenantsecurity/kms/v1/RekeyRoundTrip.java
+++ b/src/test/java/com/ironcorelabs/tenantsecurity/kms/v1/RekeyRoundTrip.java
@@ -55,6 +55,8 @@ public class RekeyRoundTrip {
                         return client.encrypt(documentMap, metadata).thenCompose(encryptedDocument -> {
                             return client.rekeyDocument(encryptedDocument, metadata, new_tenant_id)
                                     .thenCompose(encryptedDocumentRekeyed -> {
+                                        assertEquals(encryptedDocumentRekeyed.getEncryptedFields(),
+                                                encryptedDocument.getEncryptedFields());
                                         DocumentMetadata newMetadata = new DocumentMetadata(new_tenant_id,
                                                 "integrationTest", "sample", customFields, "customRayID");
                                         return client.decrypt(encryptedDocumentRekeyed, newMetadata);

--- a/src/test/java/com/ironcorelabs/tenantsecurity/kms/v1/RekeyRoundTrip.java
+++ b/src/test/java/com/ironcorelabs/tenantsecurity/kms/v1/RekeyRoundTrip.java
@@ -1,0 +1,83 @@
+package com.ironcorelabs.tenantsecurity.kms.v1;
+
+import static org.testng.Assert.assertEquals;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
+import com.ironcorelabs.tenantsecurity.kms.v1.exception.TenantSecurityException;
+import org.testng.annotations.Test;
+
+@Test(groups = { "local-integration" })
+public class RekeyRoundTrip {
+    // Default values that can be overridden by environment variables of the same name
+    // These match up to the Demo TSP whose config we ship with the repo in `benchmarks/demo-tsp.conf`.
+    private static String TENANT_ID = "tenant-gcp";
+    private static String NEW_TENANT_ID = "tenant-aws";
+    private static String API_KEY = "0WUaXesNgbTAuLwn";
+
+    private void assertEqualBytes(byte[] one, byte[] two) throws Exception {
+        assertEquals(new String(one, "UTF-8"), new String(two, "UTF-8"));
+    }
+
+    private Map<String, byte[]> getRoundtripDataToEncrypt() throws Exception {
+        Map<String, byte[]> documentMap = new HashMap<>();
+        documentMap.put("doc1", "Encrypt these bytes!".getBytes("UTF-8"));
+        documentMap.put("doc2", "And these bytes!".getBytes("UTF-8"));
+        documentMap.put("doc3", "And my axe!".getBytes("UTF-8"));
+        return documentMap;
+    }
+
+    public void roundtripTest() throws Exception {
+        Map<String, String> customFields = new HashMap<>();
+        customFields.put("org_name", "ICL");
+        customFields.put("attachment_name", "secret_music_file.mp3");
+
+        Map<String, String> envVars = System.getenv();
+        String tsp_address = envVars.getOrDefault("TSP_ADDRESS", TestSettings.TSP_ADDRESS);
+        String tsp_port = envVars.getOrDefault("TSP_PORT", TestSettings.TSP_PORT);
+        String api_key = envVars.getOrDefault("API_KEY", API_KEY);
+        String tenant_id = envVars.getOrDefault("TENANT_ID", TENANT_ID);
+        String new_tenant_id = envVars.getOrDefault("NEW_TENANT_ID", NEW_TENANT_ID);
+
+        if (tsp_port.charAt(0) != ':') {
+            tsp_port = ":" + tsp_port;
+        }
+
+        DocumentMetadata metadata = new DocumentMetadata(tenant_id, "integrationTest", "sample", customFields,
+                "customRayID");
+        Map<String, byte[]> documentMap = getRoundtripDataToEncrypt();
+
+        CompletableFuture<PlaintextDocument> roundtrip = TenantSecurityClient.create(tsp_address + tsp_port, api_key)
+                .thenCompose(client -> {
+                    try {
+                        return client.encrypt(documentMap, metadata).thenCompose(encryptedDocument -> {
+                            return client.rekeyDocument(encryptedDocument, metadata, new_tenant_id)
+                                    .thenCompose(encryptedDocumentRekeyed -> {
+                                        DocumentMetadata newMetadata = new DocumentMetadata(new_tenant_id,
+                                                "integrationTest", "sample", customFields, "customRayID");
+                                        return client.decrypt(encryptedDocumentRekeyed, newMetadata);
+                                    });
+                        });
+                    } catch (Exception e) {
+                        throw new CompletionException(e);
+                    }
+                });
+        try {
+            Map<String, byte[]> decryptedValuesMap = roundtrip.get().getDecryptedFields();
+            assertEqualBytes(decryptedValuesMap.get("doc1"), documentMap.get("doc1"));
+            assertEqualBytes(decryptedValuesMap.get("doc2"), documentMap.get("doc2"));
+            assertEqualBytes(decryptedValuesMap.get("doc3"), documentMap.get("doc3"));
+        } catch (ExecutionException e) {
+            if (e.getCause() instanceof TenantSecurityException) {
+                TenantSecurityException kmsError = (TenantSecurityException) e.getCause();
+                TenantSecurityErrorCodes errorCode = kmsError.getErrorCode();
+                System.out.println("\nError Message: " + kmsError.getMessage());
+                System.out.println("\nError Code: " + errorCode.getCode());
+                System.out.println("\nError Code Info: " + errorCode.getMessage() + "\n");
+            }
+            throw e;
+        }
+    }
+}


### PR DESCRIPTION
Add `TenantSecurityClient.rekeyDocument` method that takes an `EncryptedDocument`, `DocumentMetadata`, and new tenant ID. It calls the TSP's rekey endpoint (added in https://github.com/IronCoreLabs/tenant-security-proxy/pull/261) and returns a new `EncryptedDocument` with the new EDEK and the encrypted fields unchanged.
Also adds new test file `RekeyRoundTrip.java` that will be run as part of `LocalTest.sh` and a dev integration test
Also some typo fixes as I went to different files.
