### PR TITLE
Improve release documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,67 +2,33 @@
 
 ## Running a Tenant Security Proxy
 
-See our [TSP documentation](https://ironcorelabs.com/docs/customer-managed-keys/tenant-security-proxy/overview) for information about how to get your own TSP running to test against.
+See our [TSP documentation](https://ironcorelabs.com/docs/customer-managed-keys/tenant-security-proxy/overview) for information about how to get your own TSP running to test against. The tests will expect the TSP to be running at `http://localhost:7777`.
 
 ## Tests
 
 This client has both a set of unit tests as well as several integration test suites. Because of the complexity of the various services required to run non-unit test suites, these tests have a lot more setup required which is explained below.
 
-#### Unit Tests
+### Unit Tests
 
 Tests that check functionality that is contained within the client.
 
 - Run `test-suites/unitTest.sh`.
 
-#### Local Development Integration Tests
+### Local Development Integration Tests
 
-These tests are meant for local developers to be able to do a full end-to-end test from the client all the way through to the Config Broker. This test will perform a full round-trip encryption and decryption and verify that the data is successfully decrypted to it's original value. This test assumes that you've done the work of setting up the Tenant Security Proxy from above as well as setting up the associated Config Broker vendor account with a tenant and a KMS config. Open the [`LocalRoundTrip.java`](src/test/java/com/ironcorelabs/tenantsecurity/kms/v1/LocalRoundTrip.java) file and set the values for your `TENANT_ID` and `API_KEY` within the test class.
+These tests are meant for local developers to be able to do a full end-to-end test from the client all the way through to the Config Broker. This test will perform a full round-trip encryption and decryption and verify that the data is successfully decrypted to its original value. This test assumes that you've done the work of setting up the Tenant Security Proxy from above as well as setting up the associated Config Broker vendor account with a tenant and a KMS config. Open the [`LocalRoundTrip.java`](src/test/java/com/ironcorelabs/tenantsecurity/kms/v1/LocalRoundTrip.java) file and set the values for your `TENANT_ID` and `API_KEY` within the test class. To run tests over the batch functions, do the same for [`LocalBatch.java`](src/test/java/com/ironcorelabs/tenantsecurity/kms/v1/LocalBatch.java).
 
 Once complete, perform the following steps
 
-- Start up the Tenant Security Proxy
-- Run `test-suites/localTest.sh` to kick off the test.
+- Start up the Tenant Security Proxy.
+- Run `test-suites/localTest.sh` to run the local roundtrip test.
+- Run `test-suites/localBatchTest.sh` to run local roundtrip tests using the batch functions.
 
-#### Complete Integration Tests
+### Complete Integration Tests
 
 We've created a number of accounts within a Config Broker dev environment that have tenants set up for all the different KMS types that we support. This allows us to run a more complete suite of integration tests that exercise more parts of both the client as well as the Tenant Security Proxy. These tests are not runnable by the public. You can view the results of these test runs in [CI](https://github.com/IronCoreLabs/tenant-security-client-java/actions).
 
-## Deploy
-
-We deploy the SDK to [Maven Central](https://search.maven.org/artifact/com.ironcorelabs/tenant-security-java/).
-
-- You'll need to be authenticated and associated to our IronCore Sonatype account. This requires a user name and password for the
-  `sonatype-nexus` server to be stored in your `.m2/settings.xml` file. The user name and password we use for releasing are stored
-  on Drive in `IT_Info/sonatype-info.txt.iron`.
-- You'll also need a GPG signing key to sign the release. Decrypt `IT_Info/pgp/rsa-signing-subkey.asc.iron`, then
-  `gpg --import rsa-signing-subkey.asc`. The master password is in `IT_Info/pgp/ops-info.txt.iron`.
-- Update the `<version>` in `pom.xml`.
-- Run `mvn clean source:jar javadoc:jar deploy -Dsuite=test-suites/test-unit` to deploy the release to Maven Central.
-  **NOTE**: this command will need the passphrase associated with the GPG signing key.
-  If that hasn't been entered recently, the command will error with a "signing failed" message.
-  You need to do a signing operation like `gpg -s pom.xml`, then enter the passphrase for the key.
-  After that, re-run the `mvn` command.
-- When the artifacts have been deployed, you need to go to `https://oss.sonatype.org`, log in using the `icl-devops` username and
-  password, and find the new release in the _Staging Repositories_. You must close that repository and then release it in order to
-  actually push the package out to the public repo.
-
-This is a sample `settings.xml` file for `maven`:
-
-```
-<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
-  <localRepository>${user.home}/.m2/repository</localRepository>
-  <servers>
-    <server>
-      <id>sonatype-nexus</id>
-      <username>icl-devops</username>
-      <password>***************************</password>
-    </server>
-  </servers>
-</settings>
-```
-
-## CI Automated Tests
+### CI Automated Tests
 
 The CI job runs tests using the [tenant-security-proxy](https://github.com/IronCoreLabs/tenant-security-proxy) repo.
 If your tests don't build against the default branch of that repo, you can change it by adding a command to the pull request. The

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Tenant Security Client Java Library
 
-A Java client for implementing CMK within a vendors infrastructure. Makes requests through an
+A Java client for implementing CMK within a vendor's infrastructure. Makes requests through an
 IronCore Tenant Security Proxy to tenants' KMS/logging infrastructures.
 
 More extensive documentation about usage is available on our [docs site](https://ironcorelabs.com/docs/customer-managed-keys/tenant-security-client/overview).

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -3,6 +3,8 @@
 We deploy the SDK to [Maven Central](https://search.maven.org/artifact/com.ironcorelabs/tenant-security-java/).
 
 - Update the `<version>` in [pom.xml](./pom.xml).
+- Add an entry to [CHANGELOG.md](./CHANGELOG.md).
+- Commit the changes to the `main` branch. Wait until the release has succeeded to push the changes.
 - Put the username and password for the `icl-devops` Sonatype account into your `.m2/settings.xml` file. These credentials are stored on Drive in `IT_Info/sonatype-info.txt.iron`. A sample of this file is given below.
 - Import the GPG signing key needed to sign the release. In Google Drive, navigate to the `IT_Info/pgp` folder, download `rsa-signing-subkey.asc.iron` and `ops-info.txt.iron`, and decrypt them using IronHide. Then do the following:
   1. Copy the master password from `ops-info.txt` to your clipboard so it can be provided in step 3 when importing the secret key.
@@ -18,6 +20,7 @@ We deploy the SDK to [Maven Central](https://search.maven.org/artifact/com.ironc
     release process complete successfully.
 - When the artifacts have been deployed, go to https://oss.sonatype.org, log in using the `icl-devops` username and
   password from `sonatype-info.txt`, and find the new release in the _Staging Repositories_. Close that repository and then release it in order to actually push the package out to the public repo.
+- Push your new version and CHANGELOG entry to GitHub.
 
 ### Sample .m2/settings.xml
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -10,6 +10,7 @@ We deploy the SDK to [Maven Central](https://search.maven.org/artifact/com.ironc
   1. Copy the master password from `ops-info.txt` to your clipboard so it can be provided in step 3 when importing the secret key.
   2. `gpg --keyserver keys.gnupg.net --receive-keys 62F57B1B87928CAC`
   3. `gpg --import rsa-signing-subkey.asc`
+- Set the `JAVA_HOME` environment variable to point to your Java installation folder.
 - Run `mvn clean source:jar javadoc:jar deploy -Dsuite=test-suites/test-unit` to deploy the release to Maven Central.
   **NOTE**: this command will need the master password associated with the GPG signing key.
   If this hasn't been entered recently, the command may error with a `signing failed` message.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,36 @@
+# Releasing
+
+We deploy the SDK to [Maven Central](https://search.maven.org/artifact/com.ironcorelabs/tenant-security-java/).
+
+- Update the `<version>` in [pom.xml](./pom.xml).
+- Put the username and password for the `icl-devops` Sonatype account into your `.m2/settings.xml` file. These credentials are stored on Drive in `IT_Info/sonatype-info.txt.iron`. A sample of this file is given below.
+- Import the GPG signing key needed to sign the release. In Google Drive, navigate to the `IT_Info/pgp` folder, download `rsa-signing-subkey.asc.iron` and `ops-info.txt.iron`, and decrypt them using IronHide. Then do the following:
+  1. Copy the master password from `ops-info.txt` to your clipboard so it can be provided in step 3 when importing the secret key.
+  2. `gpg --keyserver keys.gnupg.net --receive-keys 62F57B1B87928CAC`
+  3. `gpg --import rsa-signing-subkey.asc`
+- Run `mvn clean source:jar javadoc:jar deploy -Dsuite=test-suites/test-unit` to deploy the release to Maven Central.
+  **NOTE**: this command will need the master password associated with the GPG signing key.
+  If this hasn't been entered recently, the command may error with a `signing failed` message.
+  You will need to do a signing operation like `gpg -s -u 62F57B1B87928CAC pom.xml` and then enter the master password for the key (`pom.xml.gpg` can then be deleted).
+  After that, re-run the `mvn` command above.
+  - To test the release process or to install `tenant-security-client-java` to your local machine, you can instead run
+    `mvn clean source:jar javadoc:jar install -Dsuite=test-suites/test-unit` and verify that all steps of the
+    release process complete successfully.
+- When the artifacts have been deployed, go to https://oss.sonatype.org, log in using the `icl-devops` username and
+  password from `sonatype-info.txt`, and find the new release in the _Staging Repositories_. Close that repository and then release it in order to actually push the package out to the public repo.
+
+### Sample .m2/settings.xml
+
+```
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <localRepository>${user.home}/.m2/repository</localRepository>
+  <servers>
+    <server>
+      <id>sonatype-nexus</id>
+      <username>icl-devops</username>
+      <password>***************************</password>
+    </server>
+  </servers>
+</settings>
+```

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,6 @@
     </developer>
   </developers>
 
-
   <distributionManagement>
     <snapshotRepository>
       <id>sonatype-nexus-snapshots</id>
@@ -78,13 +77,12 @@
     </dependency>
   </dependencies>
 
-
   <build>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.12.4</version>
+        <version>2.22.2</version>
         <configuration>
           <suiteXmlFiles>
             <suiteXmlFile>${suite}.xml</suiteXmlFile>
@@ -95,6 +93,9 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-gpg-plugin</artifactId>
         <version>1.6</version>
+        <configuration>
+          <keyname>62F57B1B87928CAC</keyname>
+        </configuration>
         <executions>
           <execution>
             <id>sign-artifacts</id>
@@ -108,7 +109,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.3</version>
+        <version>3.8.1</version>
         <configuration>
           <source>8</source>
           <target>8</target>
@@ -120,7 +121,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
-        <version>3.0.1</version>
+        <version>3.2.1</version>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
- Split some info from `CONTRIBUTING.md` into `RELEASING.md`. The contributing file is intended for everyone, while the releasing file is only intended for ICL employees.
- Re-wrote/clarified many steps of the release process, trying to fix common issues that developers might run into.
- Modified the signing plugin in `pom.xml` to use a specific key ID instead of just using the local machine's default key.
- Bumped some build plugin versions to their latest minor/patch versions. In the past, this has fixed issues with some steps of the release process. 

If possible, I'd appreciate 2 different people to test these directions (but only following the local install version of bullet point 6, which obviously means bullet point 7 is not needed). Ideally one person would be using a Mac.