### PR TITLE
Support x99 error codes in TenantSecurityException mapping

### DIFF
--- a/src/main/java/com/ironcorelabs/tenantsecurity/kms/v1/ErrorResponse.java
+++ b/src/main/java/com/ironcorelabs/tenantsecurity/kms/v1/ErrorResponse.java
@@ -39,11 +39,11 @@ public class ErrorResponse {
                 && TenantSecurityErrorCodes.valueOf(errorCode) != null) {
             if (errorCode == 0) {
                 return new TspServiceException(TenantSecurityErrorCodes.UNABLE_TO_MAKE_REQUEST, httpStatusCode, this.getMessage());
-            } else if (errorCode >= 100 && errorCode < 199) {
+            } else if (errorCode >= 100 && errorCode <= 199) {
                 return new TspServiceException(TenantSecurityErrorCodes.valueOf(errorCode), httpStatusCode, this.getMessage());
-            } else if (errorCode >= 200 && errorCode < 299) {
+            } else if (errorCode >= 200 && errorCode <= 299) {
                 return new KmsException(TenantSecurityErrorCodes.valueOf(errorCode), httpStatusCode, this.getMessage());
-            } else if (errorCode >= 300 && errorCode < 399) {
+            } else if (errorCode >= 300 && errorCode <= 399) {
                 return new SecurityEventException(TenantSecurityErrorCodes.valueOf(errorCode), httpStatusCode, this.getMessage());
             } else {
                 return new TspServiceException(TenantSecurityErrorCodes.UNKNOWN_ERROR, errorCode, this.getMessage());


### PR DESCRIPTION
Just something I noticed while poking around.

As-is, codes `199`, `299` and `399` would never be mapped and could be a tripping hazard far into the future.