### PR TITLE
Use functions that work on older google http lib versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.1.1
+
+- No public api changes. Internal change to increase compatibility with 1.20 google-http-client.
+
 ## v3.1.0
 
 - Added `TenantSecurityClient.rekeyDocument` method and supporting `RekeyedDocumentKey` type

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <groupId>com.ironcorelabs</groupId>
   <artifactId>tenant-security-java</artifactId>
   <packaging>jar</packaging>
-  <version>3.1.0</version>
+  <version>3.1.1</version>
   <name>tenant-security-java</name>
   <url>https://ironcorelabs.com/docs</url>
   <description>Java client library for the IronCore Labs Tenant Security Proxy.</description>

--- a/src/main/java/com/ironcorelabs/tenantsecurity/kms/v1/TenantSecurityRequest.java
+++ b/src/main/java/com/ironcorelabs/tenantsecurity/kms/v1/TenantSecurityRequest.java
@@ -54,8 +54,11 @@ final class TenantSecurityRequest implements Closeable {
 
     TenantSecurityRequest(String tspDomain, String apiKey, int requestThreadSize, int timeout) {
         HttpHeaders headers = new HttpHeaders();
-        headers.put("Content-Type", "application/json");
-        headers.put("Authorization", "cmk " + apiKey);
+        //Instead of calling `put` which causes issues with older versions of the google http library
+        //call the set for each of these.
+        headers.setContentType("application/json");
+        headers.setAuthorization("cmk " + apiKey);
+
         this.httpHeaders = headers;
 
         String tspApiPrefix = tspDomain + "/api/1/";


### PR DESCRIPTION
This is to work around #69. The actual reported issue is that calling put directly on the HttpHeaders expected a list instead of a string. We can instead use the provided `set` functions to ensure this behavior works on http-client from 1.20 as well as 1.36.

