### PR TITLE
Introduce a shaded jar in place of the normal one.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v4.0.0
+
+- Shade google-http-client and all related jars to increase compatibility with conflicting versions.
+- No public api changes, but bumping major version since we've changed the contents of our jar significantly.
+
 ## v3.1.1
 
 - No public api changes. Internal change to increase compatibility with 1.20 google-http-client.

--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>com.ironcorelabs</groupId>
             <artifactId>tenant-security-java</artifactId>
-            <version>4.0.0</version>
+            <version>3.1.1</version>
         </dependency>
     </dependencies>
 

--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>com.ironcorelabs</groupId>
             <artifactId>tenant-security-java</artifactId>
-            <version>4.0.0-SNAPSHOT</version>
+            <version>4.0.0</version>
         </dependency>
     </dependencies>
 

--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>com.ironcorelabs</groupId>
             <artifactId>tenant-security-java</artifactId>
-            <version>3.1.0</version>
+            <version>4.0.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
 

--- a/examples/large-documents/pom.xml
+++ b/examples/large-documents/pom.xml
@@ -29,7 +29,7 @@
     <dependency>
       <groupId>com.ironcorelabs</groupId>
       <artifactId>tenant-security-java</artifactId>
-      <version>4.0.0-SNAPSHOT</version>
+      <version>4.0.0</version>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>

--- a/examples/large-documents/pom.xml
+++ b/examples/large-documents/pom.xml
@@ -29,7 +29,7 @@
     <dependency>
       <groupId>com.ironcorelabs</groupId>
       <artifactId>tenant-security-java</artifactId>
-      <version>4.0.0</version>
+      <version>3.1.1</version>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>

--- a/examples/large-documents/pom.xml
+++ b/examples/large-documents/pom.xml
@@ -29,9 +29,13 @@
     <dependency>
       <groupId>com.ironcorelabs</groupId>
       <artifactId>tenant-security-java</artifactId>
-      <version>3.1.0</version>
+      <version>4.0.0-SNAPSHOT</version>
     </dependency>
-
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>30.1.1-jre</version>
+    </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>

--- a/examples/logging-example/pom.xml
+++ b/examples/logging-example/pom.xml
@@ -29,7 +29,7 @@
     <dependency>
       <groupId>com.ironcorelabs</groupId>
       <artifactId>tenant-security-java</artifactId>
-      <version>3.1.0</version>
+      <version>4.0.0-SNAPSHOT</version>
     </dependency>
 
   </dependencies>

--- a/examples/logging-example/pom.xml
+++ b/examples/logging-example/pom.xml
@@ -29,7 +29,7 @@
     <dependency>
       <groupId>com.ironcorelabs</groupId>
       <artifactId>tenant-security-java</artifactId>
-      <version>4.0.0-SNAPSHOT</version>
+      <version>4.0.0</version>
     </dependency>
 
   </dependencies>

--- a/examples/logging-example/pom.xml
+++ b/examples/logging-example/pom.xml
@@ -29,7 +29,7 @@
     <dependency>
       <groupId>com.ironcorelabs</groupId>
       <artifactId>tenant-security-java</artifactId>
-      <version>4.0.0</version>
+      <version>3.1.1</version>
     </dependency>
 
   </dependencies>

--- a/examples/rekey-example/pom.xml
+++ b/examples/rekey-example/pom.xml
@@ -28,7 +28,7 @@
     <dependency>
       <groupId>com.ironcorelabs</groupId>
       <artifactId>tenant-security-java</artifactId>
-      <version>4.0.0</version>
+      <version>3.1.1</version>
     </dependency>
   </dependencies>
 

--- a/examples/rekey-example/pom.xml
+++ b/examples/rekey-example/pom.xml
@@ -28,7 +28,7 @@
     <dependency>
       <groupId>com.ironcorelabs</groupId>
       <artifactId>tenant-security-java</artifactId>
-      <version>4.0.0-SNAPSHOT</version>
+      <version>4.0.0</version>
     </dependency>
   </dependencies>
 

--- a/examples/rekey-example/pom.xml
+++ b/examples/rekey-example/pom.xml
@@ -28,7 +28,7 @@
     <dependency>
       <groupId>com.ironcorelabs</groupId>
       <artifactId>tenant-security-java</artifactId>
-      <version>3.1.0</version>
+      <version>4.0.0-SNAPSHOT</version>
     </dependency>
   </dependencies>
 

--- a/examples/simple-roundtrip/pom.xml
+++ b/examples/simple-roundtrip/pom.xml
@@ -29,7 +29,7 @@
     <dependency>
       <groupId>com.ironcorelabs</groupId>
       <artifactId>tenant-security-java</artifactId>
-      <version>3.1.0</version>
+      <version>4.0.0-SNAPSHOT</version>
     </dependency>
 
   </dependencies>

--- a/examples/simple-roundtrip/pom.xml
+++ b/examples/simple-roundtrip/pom.xml
@@ -29,7 +29,7 @@
     <dependency>
       <groupId>com.ironcorelabs</groupId>
       <artifactId>tenant-security-java</artifactId>
-      <version>4.0.0-SNAPSHOT</version>
+      <version>4.0.0</version>
     </dependency>
 
   </dependencies>

--- a/examples/simple-roundtrip/pom.xml
+++ b/examples/simple-roundtrip/pom.xml
@@ -29,7 +29,7 @@
     <dependency>
       <groupId>com.ironcorelabs</groupId>
       <artifactId>tenant-security-java</artifactId>
-      <version>4.0.0</version>
+      <version>3.1.1</version>
     </dependency>
 
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -70,11 +70,6 @@
       <artifactId>google-http-client-apache-v2</artifactId>
     </dependency>
     <dependency>
-      <groupId>commons-logging</groupId>
-      <artifactId>commons-logging</artifactId>
-      <version>1.2</version>
-    </dependency>
-    <dependency>
       <groupId>org.testng</groupId>
       <artifactId>testng</artifactId>
       <version>6.14.2</version>
@@ -185,6 +180,10 @@
                 <relocation>
                   <pattern>io.opencensus</pattern>
                   <shadedPattern>com.ironcorelabs.shaded.opencensus</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>io.grpc</pattern>
+                  <shadedPattern>com.ironcorelabs.shaded.grpc</shadedPattern>
                 </relocation>
               </relocations>
             </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <groupId>com.ironcorelabs</groupId>
   <artifactId>tenant-security-java</artifactId>
   <packaging>jar</packaging>
-  <version>3.1.1</version>
+  <version>4.0.0-SNAPSHOT</version>
   <name>tenant-security-java</name>
   <url>https://ironcorelabs.com/docs</url>
   <description>Java client library for the IronCore Labs Tenant Security Proxy.</description>
@@ -70,6 +70,11 @@
       <artifactId>google-http-client-apache-v2</artifactId>
     </dependency>
     <dependency>
+      <groupId>commons-logging</groupId>
+      <artifactId>commons-logging</artifactId>
+      <version>1.2</version>
+    </dependency>
+    <dependency>
       <groupId>org.testng</groupId>
       <artifactId>testng</artifactId>
       <version>6.14.2</version>
@@ -122,6 +127,69 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
         <version>3.2.1</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.2.4</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <createDependencyReducedPom>true</createDependencyReducedPom>
+              <shadedArtifactAttached>false</shadedArtifactAttached>
+              <minimizeJar>true</minimizeJar>
+              <createSourcesJar>true</createSourcesJar>
+              <artifactSet>
+                <includes>
+                  <include>com.google.http-client:google-http-client-jackson2</include>
+                  <include>com.google.http-client:google-http-client-apache-v2</include>
+                  <include>com.google.guava:guava</include>
+                  <include>org.apache.httpcomponents:httpcore</include>
+                  <include>org.apache.httpcomponents:httpclient</include>
+                  <include>com.google.http-client:google-http-client</include>
+                  <include>com.google.code.findbugs:jsr305</include>
+                  <include>com.google.guava:failureaccess</include>
+                  <include>com.google.guava:listenablefuture</include>
+                  <!-- <include>org.checkerframework:checker-compat-qual</include> -->
+                  <!-- <include>com.google.errorprone:error_prone_annotations</include> -->
+                  <!-- <include>com.google.j2objc:j2objc-anwnotations</include> -->
+                  <include>io.opencensus:opencensus-api</include>
+                  <include>io.grpc:grpc-context</include>
+                  <include>io.opencensus:opencensus-contrib-http-util</include>
+                  <include>com.fasterxml.jackson.core:jackson-core</include>
+                  <!-- <include>commons-logging:commons-logging</include> -->
+                  <!-- <include>commons-codec:commons-codec</include> -->
+                </includes>
+              </artifactSet>
+              <relocations>
+                <relocation>
+                  <pattern>com.google</pattern>
+                  <shadedPattern>com.ironcorelabs.shaded.google</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.apache.http</pattern>
+                  <shadedPattern>com.ironcorelabs.shaded.apache.http</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>com.fasterxml</pattern>
+                  <shadedPattern>com.ironcorelabs.shaded.fasterxml</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>javax.annotation</pattern>
+                  <shadedPattern>com.ironcorelabs.shaded.javax.annotation</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>io.opencensus</pattern>
+                  <shadedPattern>com.ironcorelabs.shaded.opencensus</shadedPattern>
+                </relocation>
+              </relocations>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <groupId>com.ironcorelabs</groupId>
   <artifactId>tenant-security-java</artifactId>
   <packaging>jar</packaging>
-  <version>4.0.0-SNAPSHOT</version>
+  <version>4.0.0</version>
   <name>tenant-security-java</name>
   <url>https://ironcorelabs.com/docs</url>
   <description>Java client library for the IronCore Labs Tenant Security Proxy.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -174,10 +174,6 @@
                   <shadedPattern>com.ironcorelabs.shaded.fasterxml</shadedPattern>
                 </relocation>
                 <relocation>
-                  <pattern>javax.annotation</pattern>
-                  <shadedPattern>com.ironcorelabs.shaded.javax.annotation</shadedPattern>
-                </relocation>
-                <relocation>
                   <pattern>io.opencensus</pattern>
                   <shadedPattern>com.ironcorelabs.shaded.opencensus</shadedPattern>
                 </relocation>

--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,12 @@
       <groupId>com.google.http-client</groupId>
       <artifactId>google-http-client-apache-v2</artifactId>
     </dependency>
+    <!-- This is declared here because we shade the apache client, but can't shade the logging.-->
+    <dependency>
+      <groupId>commons-logging</groupId>
+      <artifactId>commons-logging</artifactId>
+      <version>1.2</version>
+    </dependency>
     <dependency>
       <groupId>org.testng</groupId>
       <artifactId>testng</artifactId>
@@ -149,15 +155,10 @@
                   <include>com.google.code.findbugs:jsr305</include>
                   <include>com.google.guava:failureaccess</include>
                   <include>com.google.guava:listenablefuture</include>
-                  <!-- <include>org.checkerframework:checker-compat-qual</include> -->
-                  <!-- <include>com.google.errorprone:error_prone_annotations</include> -->
-                  <!-- <include>com.google.j2objc:j2objc-anwnotations</include> -->
                   <include>io.opencensus:opencensus-api</include>
                   <include>io.grpc:grpc-context</include>
                   <include>io.opencensus:opencensus-contrib-http-util</include>
                   <include>com.fasterxml.jackson.core:jackson-core</include>
-                  <!-- <include>commons-logging:commons-logging</include> -->
-                  <!-- <include>commons-codec:commons-codec</include> -->
                 </includes>
               </artifactSet>
               <relocations>


### PR DESCRIPTION
This is replaces our published SDK with a shaded one to help increase compatibility with people stuck on old versions of the google http client and apache http client.

The values in the `<includes>` which are still commented out are things we're explicitly not shading.

The downsides are that we are now shipping a 2MB jar instead of 50KB.
The upsides are that we're compatible in more environments.

- [x] Should we depending on commons-logging?
- [x] Should we be shading more things?