### PR TITLE
Remove findbugs to get rid of javax.annotation in jar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v4.0.1
+
+- Remove javax.annotation from the shaded jar.
+
 ## v4.0.0
 
 - Shade google-http-client and all related jars to increase compatibility with conflicting versions.

--- a/examples/large-documents/pom.xml
+++ b/examples/large-documents/pom.xml
@@ -29,7 +29,7 @@
     <dependency>
       <groupId>com.ironcorelabs</groupId>
       <artifactId>tenant-security-java</artifactId>
-      <version>4.0.0</version>
+      <version>4.0.1-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>

--- a/examples/large-documents/pom.xml
+++ b/examples/large-documents/pom.xml
@@ -29,7 +29,7 @@
     <dependency>
       <groupId>com.ironcorelabs</groupId>
       <artifactId>tenant-security-java</artifactId>
-      <version>4.0.1-SNAPSHOT</version>
+      <version>4.0.0</version>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <groupId>com.ironcorelabs</groupId>
   <artifactId>tenant-security-java</artifactId>
   <packaging>jar</packaging>
-  <version>4.0.0</version>
+  <version>4.0.1</version>
   <name>tenant-security-java</name>
   <url>https://ironcorelabs.com/docs</url>
   <description>Java client library for the IronCore Labs Tenant Security Proxy.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -152,7 +152,6 @@
                   <include>org.apache.httpcomponents:httpcore</include>
                   <include>org.apache.httpcomponents:httpclient</include>
                   <include>com.google.http-client:google-http-client</include>
-                  <include>com.google.code.findbugs:jsr305</include>
                   <include>com.google.guava:failureaccess</include>
                   <include>com.google.guava:listenablefuture</include>
                   <include>io.opencensus:opencensus-api</include>


### PR DESCRIPTION
This is what is changed in the resulting jar.

```
--- now.txt     2021-08-09 15:48:00.680855955 -0600
+++ no-findbugs.txt     2021-08-09 15:47:35.910668124 -0600
@@ -169,20 +169,6 @@
      2613  2020-07-01 00:19   com/ironcorelabs/shaded/google/api/client/util/DataMap$Entry.class
       254  2020-07-01 00:19   com/ironcorelabs/shaded/google/api/client/util/StreamingContent.class
        33  2020-07-01 00:19   google-http-client.properties
-        0  2017-03-31 10:55   javax/
-        0  2017-03-31 10:55   javax/annotation/
-        0  2017-03-31 10:55   javax/annotation/concurrent/
-      441  2017-03-31 10:55   javax/annotation/concurrent/GuardedBy.class
-      435  2017-03-31 10:55   javax/annotation/concurrent/Immutable.class
-      437  2017-03-31 10:55   javax/annotation/concurrent/ThreadSafe.class
-        0  2017-03-31 10:55   javax/annotation/meta/
-      590  2017-03-31 10:55   javax/annotation/meta/TypeQualifier.class
-      369  2017-03-31 10:55   javax/annotation/meta/TypeQualifierNickname.class
-      520  2017-03-31 10:55   javax/annotation/meta/TypeQualifierValidator.class
-     1072  2017-03-31 10:55   javax/annotation/meta/When.class
-     1064  2017-03-31 10:55   javax/annotation/Nonnull$Checker.class
-      574  2017-03-31 10:55   javax/annotation/Nonnull.class
-      512  2017-03-31 10:55   javax/annotation/Nullable.class
         0  2020-04-13 17:14   com/ironcorelabs/shaded/google/common/
         0  2020-04-13 17:14   com/ironcorelabs/shaded/google/common/annotations/
       626  2020-04-13 17:14   com/ironcorelabs/shaded/google/common/annotations/Beta.class
@@ -1775,4 +1761,4 @@
      4909  2020-01-09 13:57   com/ironcorelabs/shaded/apache/http/message/BasicHttpResponse.class
      8159  2020-01-09 13:57   com/ironcorelabs/shaded/apache/http/message/BasicHeaderValueParser.class
 ---------                     -------
-  5733508                     1820 files
+  5723018                     1802 files
```