### PR TITLE
Remove the maven-javadoc-plugin since it works without it

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,15 +92,6 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-javadoc-plugin</artifactId>
-        <configuration>
-          <sourceFileIncludes>
-            <sourceFileInclude>target/generated-sources/*</sourceFileInclude>
-          </sourceFileIncludes>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <version>2.22.2</version>
         <configuration>


### PR DESCRIPTION
With the plugin no javadoc jar was generated. After removing it the javadoc jar was generated properly.