### PR TITLE
Add rekeyEdek function, deprecate rekeyDocument function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v4.1.0
+
+- Added `TenantSecurityClient.rekeyEdek` method
+- Deprecated `TenantSecurityClient.rekeyDocument` method
+
 ## v4.0.1
 
 - Remove javax.annotation from the shaded jar.

--- a/examples/rekey-example/pom.xml
+++ b/examples/rekey-example/pom.xml
@@ -28,7 +28,7 @@
     <dependency>
       <groupId>com.ironcorelabs</groupId>
       <artifactId>tenant-security-java</artifactId>
-      <version>4.0.0</version>
+      <version>4.1.0</version>
     </dependency>
   </dependencies>
 

--- a/examples/rekey-example/src/main/java/com/ironcorelabs/rekey/RekeyExample.java
+++ b/examples/rekey-example/src/main/java/com/ironcorelabs/rekey/RekeyExample.java
@@ -83,7 +83,8 @@ public class RekeyExample {
                             // Rekey the document to `tenant-aws` using their primary config. The
                             // metadata's name and identifying information could also be changed at
                             // this time.
-                            encrypted -> client.rekeyEdek(encrypted.getEdek(), metadata, NEW_TENANT_ID));
+                            encrypted -> new EncryptedDocument(encrypted.getEncryptedFields(), 
+                                client.rekeyEdek(encrypted.getEdek(), metadata, NEW_TENANT_ID)));
 
                     //
                     // Part 3: Decrypt the encrypted record using the new tenant

--- a/examples/rekey-example/src/main/java/com/ironcorelabs/rekey/RekeyExample.java
+++ b/examples/rekey-example/src/main/java/com/ironcorelabs/rekey/RekeyExample.java
@@ -83,7 +83,7 @@ public class RekeyExample {
                             // Rekey the document to `tenant-aws` using their primary config. The
                             // metadata's name and identifying information could also be changed at
                             // this time.
-                            encrypted -> client.rekeyDocument(encrypted, metadata, NEW_TENANT_ID));
+                            encrypted -> client.rekeyEdek(encrypted.getEdek(), metadata, NEW_TENANT_ID));
 
                     //
                     // Part 3: Decrypt the encrypted record using the new tenant

--- a/src/main/java/com/ironcorelabs/tenantsecurity/kms/v1/TenantSecurityClient.java
+++ b/src/main/java/com/ironcorelabs/tenantsecurity/kms/v1/TenantSecurityClient.java
@@ -463,8 +463,8 @@ public final class TenantSecurityClient implements Closeable {
     }
 
     /**
-     * Re-key an EncryptedDocument to a new tenant without decrypting the document data. Decrypts the
-     * document's encrypted document key (EDEK) then re-encrypts it to the new tenant. The DEK is then discarded.
+     * Re-key an EncryptedDocument using a new KMS config without decrypting the document data. Decrypts the
+     * document's encrypted document key (EDEK) then re-encrypts it using the specified tenant's current primary KMS. The DEK is then discarded.
      * The old tenant and new tenant can be the same in order to re-key the document to the tenant's latest primary config.
      *
      * @deprecated
@@ -485,9 +485,8 @@ public final class TenantSecurityClient implements Closeable {
     }
 
     /**
-     * Re-key a document's encrypted document key (EDEK) to a new tenant. Decrypts the EDEK then re-encrypts it to the new tenant. 
-     * The DEK is then discarded. The old tenant and new tenant can be the same in order to re-key the document to the tenant's 
-     * latest primary config.
+     * Re-key a document's encrypted document key (EDEK) using a new KMS config. Decrypts the EDEK then re-encrypts it using the specified tenant's current primary KMS config.
+     * The DEK is then discarded.
      *
      * @param edek        Encrypted document key to re-key.
      * @param metadata    Metadata about the EDEK being re-keyed.

--- a/src/main/java/com/ironcorelabs/tenantsecurity/kms/v1/TenantSecurityClient.java
+++ b/src/main/java/com/ironcorelabs/tenantsecurity/kms/v1/TenantSecurityClient.java
@@ -337,7 +337,6 @@ public final class TenantSecurityClient implements Closeable {
                             dek -> CryptoUtils.decryptStreamInternal(dek, input, output).join(), encryptionExecutor);
     }
 
-
     /**
      * Encrypt the provided document. Documents are provided as a map of fields from the document
      * id/name (String) to bytes (byte[]). Uses the Tenant Security Proxy to generate a new document
@@ -463,22 +462,41 @@ public final class TenantSecurityClient implements Closeable {
                 });
     }
 
-        /**
-         * Re-key an EncryptedDocument to a new tenant without decrypting the document data. Decrypts the
-         * document's encrypted document key (EDEK) then re-encrypts it to the new tenant. The DEK is then discarded.
-         * The old tenant and new tenant can be the same in order to re-key the document to the tenant's latest primary config.
-         *
-         * @param encryptedDocument Document to re-key which includes encrypted bytes as well as EDEK.
-         * @param metadata          Metadata about the document being re-keyed.
-         * @param newTenantId       Tenant ID the document should be re-keyed to.
-         * @return                  EncryptedDocument that contains the new EDEK and unaltered encrypted fields.
-         */
-        public CompletableFuture<EncryptedDocument> rekeyDocument(EncryptedDocument encryptedDocument,
-                        DocumentMetadata metadata, String newTenantId) {
-                return this.encryptionService.rekey(encryptedDocument.getEdek(), metadata, newTenantId)
-                                .thenApply(newKey -> new EncryptedDocument(encryptedDocument.getEncryptedFields(),
-                                                newKey.getEdek()));
-        }
+    /**
+     * Re-key an EncryptedDocument to a new tenant without decrypting the document data. Decrypts the
+     * document's encrypted document key (EDEK) then re-encrypts it to the new tenant. The DEK is then discarded.
+     * The old tenant and new tenant can be the same in order to re-key the document to the tenant's latest primary config.
+     *
+     * @deprecated
+     * The `rekeyEdek` method is preferred over this method because the EncryptedDocument's encrypted fields are not necessary
+     * for re-keying to take place. 
+     * 
+     * @param encryptedDocument Document to re-key which includes encrypted bytes as well as EDEK.
+     * @param metadata          Metadata about the document being re-keyed.
+     * @param newTenantId       Tenant ID the document should be re-keyed to.
+     * @return                  EncryptedDocument that contains the new EDEK and unaltered encrypted fields.
+     */
+    @Deprecated
+    public CompletableFuture<EncryptedDocument> rekeyDocument(EncryptedDocument encryptedDocument,
+            DocumentMetadata metadata, String newTenantId) {
+        return this.encryptionService.rekey(encryptedDocument.getEdek(), metadata, newTenantId)
+                .thenApply(newKey -> new EncryptedDocument(encryptedDocument.getEncryptedFields(),
+                        newKey.getEdek()));
+    }
+
+    /**
+     * Re-key a document's encrypted document key (EDEK) to a new tenant. Decrypts the EDEK then re-encrypts it to the new tenant. 
+     * The DEK is then discarded. The old tenant and new tenant can be the same in order to re-key the document to the tenant's 
+     * latest primary config.
+     *
+     * @param edek        Encrypted document key to re-key.
+     * @param metadata    Metadata about the EDEK being re-keyed.
+     * @param newTenantId Tenant ID the EDEK should be re-keyed to.
+     * @return            Newly re-keyed EDEK.
+     */
+    public CompletableFuture<String> rekeyEdek(String edek, DocumentMetadata metadata, String newTenantId) {
+        return this.encryptionService.rekey(edek, metadata, newTenantId).thenApply(newKey -> newKey.getEdek());
+    }
 
     /**
      * Decrypt a map of documents from the ID of the document to its encrypted content. Makes a call


### PR DESCRIPTION
Changes re-keying to be more intuitive - because they document fields aren't needed for re-keying, they shouldn't need to be passed in. This adds a new rekeyEdek function and deprecates the old function.

Re-key example won't work until we release the new version of the TSC.