### PR TITLE
Add TenantSecurityErrorCode for KMS_ACCOUNT_ISSUE.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Compatibility
 
-KMS_ACCOUNT_ISSUE requires TSP 4.13.0+. If using TSP >=4.13.0, these errors will come through as UNKNOWN_ERROR.
+KMS_ACCOUNT_ISSUE requires TSP 4.13.0+. If using TSC < 7.2.0 and TSP >= 4.13.0, these errors will come through as UNKNOWN_ERROR.
 
 ## v7.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v7.2.0
+
+- Support TSP error code for KMS_ACCOUNT_ISSUE.
+
+### Compatibility
+
+KMS_ACCOUNT_ISSUE requires TSP 4.13.0+. If using TSP >=4.13.0, these errors will come through as UNKNOWN_ERROR.
+
 ## v7.1.0
 
 - Send TSC language/version as headers on requests to the TSP. This will allow the TSP to report TSC versions along with its [metrics](https://ironcorelabs.com/docs/saas-shield/tenant-security-proxy/deployment/#metrics).

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   <groupId>com.ironcorelabs</groupId>
   <artifactId>tenant-security-java</artifactId>
   <packaging>jar</packaging>
-  <version>7.1.0</version>
+  <version>7.2.0</version>
   <name>tenant-security-java</name>
   <url>https://ironcorelabs.com/docs</url>
   <description>Java client library for the IronCore Labs Tenant Security Proxy.</description>

--- a/src/main/java/com/ironcorelabs/tenantsecurity/kms/v1/TenantSecurityErrorCodes.java
+++ b/src/main/java/com/ironcorelabs/tenantsecurity/kms/v1/TenantSecurityErrorCodes.java
@@ -30,7 +30,7 @@ public enum TenantSecurityErrorCodes {
       "Request to KMS failed because the key configuration was invalid or the necessary permissions for the operation were missing/revoked."),
   KMS_UNREACHABLE(208, "Request to KMS failed because KMS was unreachable."),
   KMS_THROTTLED(209, "Request to KMS failed because KMS throttled the Tenant Security Proxy."),
-
+  KMS_ACCOUNT_ISSUE(210, "Request to KMS failed because of an issue with the KMS account."),
   // map to SecurityEventException
   SECURITY_EVENT_REJECTED(301, "Tenant Security Proxy could not accept the security event"),
 

--- a/src/main/java/com/ironcorelabs/tenantsecurity/kms/v1/TenantSecurityRequest.java
+++ b/src/main/java/com/ironcorelabs/tenantsecurity/kms/v1/TenantSecurityRequest.java
@@ -55,7 +55,7 @@ final class TenantSecurityRequest implements Closeable {
   private final int timeout;
 
   // TSC version that will be sent to the TSP.
-  static final String sdkVersion = "7.1.0";
+  static final String sdkVersion = "7.2.0";
 
   TenantSecurityRequest(String tspDomain, String apiKey, int requestThreadSize, int timeout) {
     HttpHeaders headers = new HttpHeaders();

--- a/src/test/java/com/ironcorelabs/tenantsecurity/kms/v1/ErrorResponseTest.java
+++ b/src/test/java/com/ironcorelabs/tenantsecurity/kms/v1/ErrorResponseTest.java
@@ -1,0 +1,156 @@
+package com.ironcorelabs.tenantsecurity.kms.v1;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.nio.ByteBuffer;
+import java.security.SecureRandom;
+import java.util.Arrays;
+import java.util.stream.IntStream;
+import org.testng.annotations.Test;
+import com.ironcorelabs.tenantsecurity.kms.v1.exception.KmsException;
+import com.ironcorelabs.tenantsecurity.kms.v1.exception.SecurityEventException;
+import com.ironcorelabs.tenantsecurity.kms.v1.exception.TenantSecurityException;
+import com.ironcorelabs.tenantsecurity.kms.v1.exception.TspServiceException;
+
+@Test(groups = {"unit"})
+public class ErrorResponseTest {
+
+  public void exceptionFromErrorResponseTspServiceException() throws Exception {
+    final String staticMsg = "static message";
+    final int staticHttpCode = 42;
+
+    // TspServiceException
+    ErrorResponse unableToMakeReqError =
+        new ErrorResponse(TenantSecurityErrorCodes.UNABLE_TO_MAKE_REQUEST.getCode(), staticMsg);
+    TenantSecurityException unableToMakeReqException =
+        unableToMakeReqError.toTenantSecurityException(staticHttpCode);
+    assertTspServiceException(staticMsg, staticHttpCode, unableToMakeReqException,
+        TenantSecurityErrorCodes.UNABLE_TO_MAKE_REQUEST);
+
+    ErrorResponse unknownErrResp =
+        new ErrorResponse(TenantSecurityErrorCodes.UNKNOWN_ERROR.getCode(), staticMsg);
+    TenantSecurityException unknownErrException =
+        unknownErrResp.toTenantSecurityException(staticHttpCode);
+    assertTspServiceException(staticMsg, staticHttpCode, unknownErrException,
+        TenantSecurityErrorCodes.UNKNOWN_ERROR);
+
+    ErrorResponse invalidRequestBody =
+        new ErrorResponse(TenantSecurityErrorCodes.INVALID_REQUEST_BODY.getCode(), staticMsg);
+    TenantSecurityException invalidRequestException =
+        invalidRequestBody.toTenantSecurityException(staticHttpCode);
+    assertTspServiceException(staticMsg, staticHttpCode, invalidRequestException,
+        TenantSecurityErrorCodes.INVALID_REQUEST_BODY);
+
+    ErrorResponse unauthorizedReqErrResp =
+        new ErrorResponse(TenantSecurityErrorCodes.UNAUTHORIZED_REQUEST.getCode(), staticMsg);
+    TenantSecurityException unauthorizedReqException =
+        unauthorizedReqErrResp.toTenantSecurityException(staticHttpCode);
+    assertTspServiceException(staticMsg, staticHttpCode, unauthorizedReqException,
+        TenantSecurityErrorCodes.UNAUTHORIZED_REQUEST);
+
+    // KmsException
+    ErrorResponse noPrimaryKmsResp = new ErrorResponse(
+        TenantSecurityErrorCodes.NO_PRIMARY_KMS_CONFIGURATION.getCode(), staticMsg);
+    TenantSecurityException noPrimaryKmsException =
+        noPrimaryKmsResp.toTenantSecurityException(staticHttpCode);
+    assertKmsException(staticMsg, staticHttpCode, noPrimaryKmsException,
+        TenantSecurityErrorCodes.NO_PRIMARY_KMS_CONFIGURATION);
+
+    ErrorResponse unknownTenantError = new ErrorResponse(
+        TenantSecurityErrorCodes.UNKNOWN_TENANT_OR_NO_ACTIVE_KMS_CONFIGURATIONS.getCode(),
+        staticMsg);
+    TenantSecurityException unknownTenantException =
+        unknownTenantError.toTenantSecurityException(staticHttpCode);
+    assertKmsException(staticMsg, staticHttpCode, unknownTenantException,
+        TenantSecurityErrorCodes.UNKNOWN_TENANT_OR_NO_ACTIVE_KMS_CONFIGURATIONS);
+
+    ErrorResponse kmsCfgDisabledError =
+        new ErrorResponse(TenantSecurityErrorCodes.KMS_CONFIGURATION_DISABLED.getCode(), staticMsg);
+    TenantSecurityException kmsCfgDisabledException =
+        kmsCfgDisabledError.toTenantSecurityException(staticHttpCode);
+    assertKmsException(staticMsg, staticHttpCode, kmsCfgDisabledException,
+        TenantSecurityErrorCodes.KMS_CONFIGURATION_DISABLED);
+
+    ErrorResponse invalidEdekErrResp =
+        new ErrorResponse(TenantSecurityErrorCodes.INVALID_PROVIDED_EDEK.getCode(), staticMsg);
+    TenantSecurityException invalidEdekException =
+        invalidEdekErrResp.toTenantSecurityException(staticHttpCode);
+    assertKmsException(staticMsg, staticHttpCode, invalidEdekException,
+        TenantSecurityErrorCodes.INVALID_PROVIDED_EDEK);
+
+    ErrorResponse unwrapError =
+        new ErrorResponse(TenantSecurityErrorCodes.KMS_UNWRAP_FAILED.getCode(), staticMsg);
+    TenantSecurityException unwrapException = unwrapError.toTenantSecurityException(staticHttpCode);
+    assertKmsException(staticMsg, staticHttpCode, unwrapException,
+        TenantSecurityErrorCodes.KMS_UNWRAP_FAILED);
+
+    ErrorResponse wrapError =
+        new ErrorResponse(TenantSecurityErrorCodes.KMS_WRAP_FAILED.getCode(), staticMsg);
+    TenantSecurityException kmsWrapException = wrapError.toTenantSecurityException(staticHttpCode);
+    assertKmsException(staticMsg, staticHttpCode, kmsWrapException,
+        TenantSecurityErrorCodes.KMS_WRAP_FAILED);
+
+    ErrorResponse kmsAuthError =
+        new ErrorResponse(TenantSecurityErrorCodes.KMS_AUTHORIZATION_FAILED.getCode(), staticMsg);
+    TenantSecurityException kmsAuthException =
+        kmsAuthError.toTenantSecurityException(staticHttpCode);
+    assertKmsException(staticMsg, staticHttpCode, kmsAuthException,
+        TenantSecurityErrorCodes.KMS_AUTHORIZATION_FAILED);
+
+    ErrorResponse kmsConfigInvalidError =
+        new ErrorResponse(TenantSecurityErrorCodes.KMS_CONFIGURATION_INVALID.getCode(), staticMsg);
+    TenantSecurityException kmsConfigInvalidException =
+        kmsConfigInvalidError.toTenantSecurityException(staticHttpCode);
+    assertKmsException(staticMsg, staticHttpCode, kmsConfigInvalidException,
+        TenantSecurityErrorCodes.KMS_CONFIGURATION_INVALID);
+
+    ErrorResponse foo =
+        new ErrorResponse(TenantSecurityErrorCodes.KMS_ACCOUNT_ISSUE.getCode(), staticMsg);
+    TenantSecurityException fooException = foo.toTenantSecurityException(staticHttpCode);
+    assertKmsException(staticMsg, staticHttpCode, fooException,
+        TenantSecurityErrorCodes.KMS_ACCOUNT_ISSUE);
+
+    ErrorResponse kmsUnreachableError =
+        new ErrorResponse(TenantSecurityErrorCodes.KMS_UNREACHABLE.getCode(), staticMsg);
+    TenantSecurityException kmsUnreachableException =
+        kmsUnreachableError.toTenantSecurityException(staticHttpCode);
+    assertKmsException(staticMsg, staticHttpCode, kmsUnreachableException,
+        TenantSecurityErrorCodes.KMS_UNREACHABLE);
+
+    // SecurityEventException
+    ErrorResponse securityEventRejectedError =
+        new ErrorResponse(TenantSecurityErrorCodes.SECURITY_EVENT_REJECTED.getCode(), staticMsg);
+    TenantSecurityException securityEventRejectedException =
+        securityEventRejectedError.toTenantSecurityException(staticHttpCode);
+    assertSecurityEventException(staticMsg, staticHttpCode, securityEventRejectedException,
+        TenantSecurityErrorCodes.SECURITY_EVENT_REJECTED);
+  }
+
+  private void assertTspServiceException(String expectedMsg, int expectedHttpStatusCode,
+      TenantSecurityException exception, TenantSecurityErrorCodes errorCode) {
+    assertTenantSecurityException(expectedMsg, expectedHttpStatusCode, exception, errorCode);
+    assertTrue(exception instanceof TspServiceException);
+  }
+
+  private void assertSecurityEventException(String expectedMsg, int expectedHttpStatusCode,
+      TenantSecurityException exception, TenantSecurityErrorCodes errorCode) {
+    assertTenantSecurityException(expectedMsg, expectedHttpStatusCode, exception, errorCode);
+    assertTrue(exception instanceof SecurityEventException);
+  }
+
+  private void assertKmsException(String expectedMsg, int expectedHttpStatusCode,
+      TenantSecurityException exception, TenantSecurityErrorCodes errorCode) {
+    assertTenantSecurityException(expectedMsg, expectedHttpStatusCode, exception, errorCode);
+    assertTrue(exception instanceof KmsException);
+  }
+
+  private void assertTenantSecurityException(String expectedMsg, int expectedHttpStatusCode,
+      TenantSecurityException exception, TenantSecurityErrorCodes errorCode) {
+    assertEquals(errorCode, exception.getErrorCode());
+    assertEquals(exception.getHttpResponseCode(), expectedHttpStatusCode);
+    assertEquals(exception.getMessage(), expectedMsg);
+  }
+
+}

--- a/src/test/java/com/ironcorelabs/tenantsecurity/kms/v1/KMSRequestTest.java
+++ b/src/test/java/com/ironcorelabs/tenantsecurity/kms/v1/KMSRequestTest.java
@@ -9,11 +9,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-
-import com.ironcorelabs.tenantsecurity.kms.v1.exception.KmsException;
-import com.ironcorelabs.tenantsecurity.kms.v1.exception.SecurityEventException;
 import com.ironcorelabs.tenantsecurity.kms.v1.exception.TenantSecurityException;
-import com.ironcorelabs.tenantsecurity.kms.v1.exception.TspServiceException;
 import org.testng.annotations.Test;
 
 @Test(groups = {"dev-integration"})
@@ -83,136 +79,6 @@ public class KMSRequestTest {
       TenantSecurityException esError = (TenantSecurityException) e.getCause();
       assertEquals(esError.getErrorCode(), TenantSecurityErrorCodes.INVALID_PROVIDED_EDEK);
     }
-  }
-
-  public void exceptionFromErrorResponseTspServiceException() throws Exception {
-    final String staticMsg = "static message";
-    final int staticHttpCode = 42;
-
-    // TspServiceException
-    ErrorResponse unableToMakeReqError =
-        new ErrorResponse(TenantSecurityErrorCodes.UNABLE_TO_MAKE_REQUEST.getCode(), staticMsg);
-    TenantSecurityException unableToMakeReqException =
-        unableToMakeReqError.toTenantSecurityException(staticHttpCode);
-    assertTspServiceException(staticMsg, staticHttpCode, unableToMakeReqException,
-        TenantSecurityErrorCodes.UNABLE_TO_MAKE_REQUEST);
-
-    ErrorResponse unknownErrResp =
-        new ErrorResponse(TenantSecurityErrorCodes.UNKNOWN_ERROR.getCode(), staticMsg);
-    TenantSecurityException unknownErrException =
-        unknownErrResp.toTenantSecurityException(staticHttpCode);
-    assertTspServiceException(staticMsg, staticHttpCode, unknownErrException,
-        TenantSecurityErrorCodes.UNKNOWN_ERROR);
-
-    ErrorResponse invalidRequestBody =
-        new ErrorResponse(TenantSecurityErrorCodes.INVALID_REQUEST_BODY.getCode(), staticMsg);
-    TenantSecurityException invalidRequestException =
-        invalidRequestBody.toTenantSecurityException(staticHttpCode);
-    assertTspServiceException(staticMsg, staticHttpCode, invalidRequestException,
-        TenantSecurityErrorCodes.INVALID_REQUEST_BODY);
-
-    ErrorResponse unauthorizedReqErrResp =
-        new ErrorResponse(TenantSecurityErrorCodes.UNAUTHORIZED_REQUEST.getCode(), staticMsg);
-    TenantSecurityException unauthorizedReqException =
-        unauthorizedReqErrResp.toTenantSecurityException(staticHttpCode);
-    assertTspServiceException(staticMsg, staticHttpCode, unauthorizedReqException,
-        TenantSecurityErrorCodes.UNAUTHORIZED_REQUEST);
-
-    // KmsException
-    ErrorResponse noPrimaryKmsResp = new ErrorResponse(
-        TenantSecurityErrorCodes.NO_PRIMARY_KMS_CONFIGURATION.getCode(), staticMsg);
-    TenantSecurityException noPrimaryKmsException =
-        noPrimaryKmsResp.toTenantSecurityException(staticHttpCode);
-    assertKmsException(staticMsg, staticHttpCode, noPrimaryKmsException,
-        TenantSecurityErrorCodes.NO_PRIMARY_KMS_CONFIGURATION);
-
-    ErrorResponse unknownTenantError = new ErrorResponse(
-        TenantSecurityErrorCodes.UNKNOWN_TENANT_OR_NO_ACTIVE_KMS_CONFIGURATIONS.getCode(),
-        staticMsg);
-    TenantSecurityException unknownTenantException =
-        unknownTenantError.toTenantSecurityException(staticHttpCode);
-    assertKmsException(staticMsg, staticHttpCode, unknownTenantException,
-        TenantSecurityErrorCodes.UNKNOWN_TENANT_OR_NO_ACTIVE_KMS_CONFIGURATIONS);
-
-    ErrorResponse kmsCfgDisabledError =
-        new ErrorResponse(TenantSecurityErrorCodes.KMS_CONFIGURATION_DISABLED.getCode(), staticMsg);
-    TenantSecurityException kmsCfgDisabledException =
-        kmsCfgDisabledError.toTenantSecurityException(staticHttpCode);
-    assertKmsException(staticMsg, staticHttpCode, kmsCfgDisabledException,
-        TenantSecurityErrorCodes.KMS_CONFIGURATION_DISABLED);
-
-    ErrorResponse invalidEdekErrResp =
-        new ErrorResponse(TenantSecurityErrorCodes.INVALID_PROVIDED_EDEK.getCode(), staticMsg);
-    TenantSecurityException invalidEdekException =
-        invalidEdekErrResp.toTenantSecurityException(staticHttpCode);
-    assertKmsException(staticMsg, staticHttpCode, invalidEdekException,
-        TenantSecurityErrorCodes.INVALID_PROVIDED_EDEK);
-
-    ErrorResponse unwrapError =
-        new ErrorResponse(TenantSecurityErrorCodes.KMS_UNWRAP_FAILED.getCode(), staticMsg);
-    TenantSecurityException unwrapException = unwrapError.toTenantSecurityException(staticHttpCode);
-    assertKmsException(staticMsg, staticHttpCode, unwrapException,
-        TenantSecurityErrorCodes.KMS_UNWRAP_FAILED);
-
-    ErrorResponse wrapError =
-        new ErrorResponse(TenantSecurityErrorCodes.KMS_WRAP_FAILED.getCode(), staticMsg);
-    TenantSecurityException kmsWrapException = wrapError.toTenantSecurityException(staticHttpCode);
-    assertKmsException(staticMsg, staticHttpCode, kmsWrapException,
-        TenantSecurityErrorCodes.KMS_WRAP_FAILED);
-
-    ErrorResponse kmsAuthError =
-        new ErrorResponse(TenantSecurityErrorCodes.KMS_AUTHORIZATION_FAILED.getCode(), staticMsg);
-    TenantSecurityException kmsAuthException =
-        kmsAuthError.toTenantSecurityException(staticHttpCode);
-    assertKmsException(staticMsg, staticHttpCode, kmsAuthException,
-        TenantSecurityErrorCodes.KMS_AUTHORIZATION_FAILED);
-
-    ErrorResponse kmsConfigInvalidError =
-        new ErrorResponse(TenantSecurityErrorCodes.KMS_CONFIGURATION_INVALID.getCode(), staticMsg);
-    TenantSecurityException kmsConfigInvalidException =
-        kmsConfigInvalidError.toTenantSecurityException(staticHttpCode);
-    assertKmsException(staticMsg, staticHttpCode, kmsConfigInvalidException,
-        TenantSecurityErrorCodes.KMS_CONFIGURATION_INVALID);
-
-    ErrorResponse kmsUnreachableError =
-        new ErrorResponse(TenantSecurityErrorCodes.KMS_UNREACHABLE.getCode(), staticMsg);
-    TenantSecurityException kmsUnreachableException =
-        kmsUnreachableError.toTenantSecurityException(staticHttpCode);
-    assertKmsException(staticMsg, staticHttpCode, kmsUnreachableException,
-        TenantSecurityErrorCodes.KMS_UNREACHABLE);
-
-    // SecurityEventException
-    ErrorResponse securityEventRejectedError =
-        new ErrorResponse(TenantSecurityErrorCodes.SECURITY_EVENT_REJECTED.getCode(), staticMsg);
-    TenantSecurityException securityEventRejectedException =
-        securityEventRejectedError.toTenantSecurityException(staticHttpCode);
-    assertSecurityEventException(staticMsg, staticHttpCode, securityEventRejectedException,
-        TenantSecurityErrorCodes.SECURITY_EVENT_REJECTED);
-  }
-
-  private void assertTspServiceException(String expectedMsg, int expectedHttpStatusCode,
-      TenantSecurityException exception, TenantSecurityErrorCodes errorCode) {
-    assertTenantSecurityException(expectedMsg, expectedHttpStatusCode, exception, errorCode);
-    assertTrue(exception instanceof TspServiceException);
-  }
-
-  private void assertSecurityEventException(String expectedMsg, int expectedHttpStatusCode,
-      TenantSecurityException exception, TenantSecurityErrorCodes errorCode) {
-    assertTenantSecurityException(expectedMsg, expectedHttpStatusCode, exception, errorCode);
-    assertTrue(exception instanceof SecurityEventException);
-  }
-
-  private void assertKmsException(String expectedMsg, int expectedHttpStatusCode,
-      TenantSecurityException exception, TenantSecurityErrorCodes errorCode) {
-    assertTenantSecurityException(expectedMsg, expectedHttpStatusCode, exception, errorCode);
-    assertTrue(exception instanceof KmsException);
-  }
-
-  private void assertTenantSecurityException(String expectedMsg, int expectedHttpStatusCode,
-      TenantSecurityException exception, TenantSecurityErrorCodes errorCode) {
-    assertEquals(errorCode, exception.getErrorCode());
-    assertEquals(exception.getHttpResponseCode(), expectedHttpStatusCode);
-    assertEquals(exception.getMessage(), expectedMsg);
   }
 
 }


### PR DESCRIPTION
Adds support for the new (TSP 4.13.0+) error code `KMS_ACCOUNT_ISSUE` which indicates if there is an error with the kms account.