### PR TITLE
Update google libraries and shading plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v7.2.1
+
+- Update dependencies to fix CVEs.
+
 ## v7.2.0
 
 - Support TSP error code for KMS_ACCOUNT_ISSUE.

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   <groupId>com.ironcorelabs</groupId>
   <artifactId>tenant-security-java</artifactId>
   <packaging>jar</packaging>
-  <version>7.2.0</version>
+  <version>7.2.1</version>
   <name>tenant-security-java</name>
   <url>https://ironcorelabs.com/docs</url>
   <description>Java client library for the IronCore Labs Tenant Security Proxy.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>libraries-bom</artifactId>
-        <version>10.1.0</version>
+        <version>26.57.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -177,7 +177,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>3.2.4</version>
+        <version>3.5.3</version>
         <executions>
           <execution>
             <phase>package</phase>

--- a/src/main/java/com/ironcorelabs/tenantsecurity/kms/v1/TenantSecurityRequest.java
+++ b/src/main/java/com/ironcorelabs/tenantsecurity/kms/v1/TenantSecurityRequest.java
@@ -55,7 +55,7 @@ final class TenantSecurityRequest implements Closeable {
   private final int timeout;
 
   // TSC version that will be sent to the TSP.
-  static final String sdkVersion = "7.2.0";
+  static final String sdkVersion = "7.2.1";
 
   TenantSecurityRequest(String tspDomain, String apiKey, int requestThreadSize, int timeout) {
     HttpHeaders headers = new HttpHeaders();


### PR DESCRIPTION
Fixes #139 

Dependabot wasn't updating this dependency because it's part of the bom package and not declared specifically. 